### PR TITLE
feat: tighten tenant overlay secret validation

### DIFF
--- a/apps/admin/messages/en-IE/common.json
+++ b/apps/admin/messages/en-IE/common.json
@@ -18,7 +18,8 @@
     "freshness": "Freshness",
     "orgs": "Orgs",
     "dsr": "DSR",
-    "cases": "Cases"
+    "cases": "Cases",
+    "stepTypes": "Step types"
   },
   "dashboard": {
     "heading": "Operational overview",
@@ -174,6 +175,73 @@
     },
     "reason": {
       "submitting": "Submitting\u2026"
+    }
+  },
+  "stepTypes": {
+    "heading": "Step type registry",
+    "subheading": "Publish, install, and audit tenant overlays.",
+    "registry": {
+      "slug": "Slug: {slug}",
+      "category": "Category: {category}",
+      "latest": "Latest version: {version}",
+      "published": "Published versions: {count}"
+    },
+    "versions": {
+      "title": "Version timeline",
+      "subtitle": "Track drafts and published releases.",
+      "caption": "Step type versions",
+      "empty": "No versions published yet.",
+      "columns": {
+        "stepType": "Step type",
+        "version": "Version",
+        "status": "Status",
+        "schema": "Input schema",
+        "publishedAt": "Published"
+      },
+      "status": {
+        "draft": "Draft",
+        "published": "Published"
+      }
+    },
+    "installs": {
+      "title": "Tenant installs",
+      "subtitle": "Tenants pinned to registry versions.",
+      "caption": "Enabled tenants",
+      "empty": "No tenant installs yet.",
+      "columns": {
+        "tenant": "Tenant",
+        "version": "Step version",
+        "status": "Status",
+        "installedAt": "Installed"
+      },
+      "status": {
+        "enabled": "Enabled",
+        "disabled": "Disabled"
+      }
+    },
+    "secrets": {
+      "title": "Secret bindings",
+      "subtitle": "Aliases mapped to tenant vault entries.",
+      "caption": "Active secret aliases",
+      "empty": "No secret bindings configured.",
+      "columns": {
+        "tenant": "Tenant",
+        "alias": "Alias",
+        "provider": "Provider",
+        "externalId": "External reference"
+      }
+    },
+    "overlays": {
+      "title": "Overlay snapshots",
+      "subtitle": "Recent merged workflow snapshots per tenant.",
+      "caption": "Latest overlay activity",
+      "empty": "No overlay snapshots captured.",
+      "columns": {
+        "workflow": "Workflow",
+        "tenant": "Tenant",
+        "count": "Overlays",
+        "createdAt": "Captured"
+      }
     }
   }
 }

--- a/apps/admin/messages/ga-IE/common.json
+++ b/apps/admin/messages/ga-IE/common.json
@@ -18,7 +18,8 @@
     "freshness": "Úire",
     "orgs": "Eagraíochtaí",
     "dsr": "DSR",
-    "cases": "Cásanna"
+    "cases": "Cásanna",
+    "stepTypes": "Cineálacha céime"
   },
   "dashboard": {
     "heading": "Forbhreathnú oibríochtúil",
@@ -174,6 +175,73 @@
     },
     "reason": {
       "submitting": "Á chur isteach…"
+    }
+  },
+  "stepTypes": {
+    "heading": "Clárlann cineálacha céime",
+    "subheading": "Foilsigh, suiteáil, agus iniúchtaigh forleagain tionant.",
+    "registry": {
+      "slug": "Slog: {slug}",
+      "category": "Catagóir: {category}",
+      "latest": "Leagan is déanaí: {version}",
+      "published": "Leaganacha foilsithe: {count}"
+    },
+    "versions": {
+      "title": "Amlíne leagan",
+      "subtitle": "Rianaigh dréachtaí agus eisiúintí foilsithe.",
+      "caption": "Leaganacha cineál céime",
+      "empty": "Níl leagan ar bith foilsithe fós.",
+      "columns": {
+        "stepType": "Cineál céime",
+        "version": "Leagan",
+        "status": "Stádas",
+        "schema": "Scéimre ionchuir",
+        "publishedAt": "Foilsithe"
+      },
+      "status": {
+        "draft": "Dréacht",
+        "published": "Foilsithe"
+      }
+    },
+    "installs": {
+      "title": "Suiteálacha tionant",
+      "subtitle": "Tionant ag gabháil le leaganacha clárlainne.",
+      "caption": "Tionantanna cumasaithe",
+      "empty": "Níl suiteáil tionant ann fós.",
+      "columns": {
+        "tenant": "Tionant",
+        "version": "Leagan céime",
+        "status": "Stádas",
+        "installedAt": "Suiteáilte"
+      },
+      "status": {
+        "enabled": "Cumasaithe",
+        "disabled": "Díchumasaithe"
+      }
+    },
+    "secrets": {
+      "title": "Ceangail rúin",
+      "subtitle": "Ailiasanna nasctha le hiontrálacha taisce an tionant.",
+      "caption": "Ailiasanna rúin gníomhacha",
+      "empty": "Níl aon cheangal rúin cumraithe.",
+      "columns": {
+        "tenant": "Tionant",
+        "alias": "Ailias",
+        "provider": "Soláthraí",
+        "externalId": "Tagairt sheachtrach"
+      }
+    },
+    "overlays": {
+      "title": "Snapshots forleagain",
+      "subtitle": "Snapshots comhleáite le déanaí in aghaidh tionant.",
+      "caption": "Gníomhaíocht forleagain is déanaí",
+      "empty": "Níor gabhadh snapshots forleagain fós.",
+      "columns": {
+        "workflow": "Sreabhadh oibre",
+        "tenant": "Tionant",
+        "count": "Forleagain",
+        "createdAt": "Gafa"
+      }
     }
   }
 }

--- a/apps/admin/src/app/[locale]/(dashboard)/layout.tsx
+++ b/apps/admin/src/app/[locale]/(dashboard)/layout.tsx
@@ -14,7 +14,8 @@ const navigation = [
   { href: "/freshness", messageKey: "freshness" },
   { href: "/orgs", messageKey: "orgs" },
   { href: "/dsr", messageKey: "dsr" },
-  { href: "/cases", messageKey: "cases" }
+  { href: "/cases", messageKey: "cases" },
+  { href: "/step-types", messageKey: "stepTypes" }
 ] as const;
 
 export function generateStaticParams() {

--- a/apps/admin/src/app/[locale]/step-types/page.tsx
+++ b/apps/admin/src/app/[locale]/step-types/page.tsx
@@ -1,0 +1,257 @@
+import { Card, Flex, Grid, Heading, Text } from "@radix-ui/themes";
+import { getTranslations } from "next-intl/server";
+import { DataTable } from "../../../components/DataTable";
+import { getSupabaseUser } from "../../../lib/auth/supabase-ssr";
+import { requireRole, type AdminRole } from "../../../lib/rbac";
+
+const registry = [
+  {
+    id: "stp-temporal-webhook",
+    slug: "temporal.webhook",
+    title: "Temporal Webhook Bridge",
+    category: "automation",
+    latestVersion: "1.4.0",
+    summary: "Bridges tenant webhooks with managed Temporal workflows.",
+    publishedVersions: 3,
+  },
+  {
+    id: "stp-manual-review",
+    slug: "manual.review",
+    title: "Manual Review with Evidence",
+    category: "governance",
+    latestVersion: "2.1.0",
+    summary: "Collect reviewer notes and ensure dual-control sign-off.",
+    publishedVersions: 4,
+  },
+];
+
+const versionLedger = [
+  {
+    id: "stv-1",
+    stepType: "temporal.webhook",
+    version: "1.4.0",
+    status: "published",
+    publishedAt: "2025-10-01",
+    schemaSlug: "schemas/webhook-input@1",
+  },
+  {
+    id: "stv-2",
+    stepType: "manual.review",
+    version: "2.1.0",
+    status: "published",
+    publishedAt: "2025-09-14",
+    schemaSlug: "schemas/review-checklist@2",
+  },
+  {
+    id: "stv-3",
+    stepType: "manual.review",
+    version: "2.2.0",
+    status: "draft",
+    publishedAt: "—",
+    schemaSlug: "schemas/review-checklist@3",
+  },
+];
+
+const tenantInstalls = [
+  {
+    id: "install-1",
+    tenant: "Company X",
+    orgSlug: "company-x",
+    stepTypeVersion: "temporal.webhook@1.4.0",
+    status: "enabled",
+    installedAt: "2025-10-05",
+  },
+  {
+    id: "install-2",
+    tenant: "Acme Foundation",
+    orgSlug: "acme-foundation",
+    stepTypeVersion: "manual.review@2.1.0",
+    status: "enabled",
+    installedAt: "2025-09-18",
+  },
+];
+
+const secretBindings = [
+  {
+    id: "secret-1",
+    tenant: "Company X",
+    alias: "secrets.crm.apiToken",
+    provider: "HashiCorp Vault",
+    externalId: "kv/data/company-x/crm",
+  },
+  {
+    id: "secret-2",
+    tenant: "Acme Foundation",
+    alias: "secrets.temporal.taskQueueKey",
+    provider: "AWS Secrets Manager",
+    externalId: "arn:aws:secretsmanager:eu-west-1:123456789:key",
+  },
+];
+
+const overlayActivity = [
+  {
+    id: "snapshot-1",
+    workflow: "setup-nonprofit-ie-charity",
+    tenant: "Company X",
+    overlays: 2,
+    createdAt: "2025-10-06",
+  },
+  {
+    id: "snapshot-2",
+    workflow: "setup-nonprofit-ie-charity",
+    tenant: "Acme Foundation",
+    overlays: 1,
+    createdAt: "2025-09-22",
+  },
+];
+
+export default async function StepTypesPage() {
+  const t = await getTranslations({ namespace: "stepTypes" });
+
+  try {
+    const user = await getSupabaseUser();
+    const role = (user?.app_metadata?.admin_role ?? user?.user_metadata?.admin_role) as AdminRole | undefined;
+    if (role) {
+      requireRole({ role }, ["platform_admin", "support_agent"]);
+    }
+  } catch (error) {
+    console.warn("Supabase unavailable for step types RBAC", error);
+  }
+
+  return (
+    <Flex direction="column" gap="5">
+      <section>
+        <Heading size="8">{t("heading")}</Heading>
+        <Text size="3" color="gray">{t("subheading")}</Text>
+      </section>
+
+      <Grid columns={{ initial: "1", md: "2" }} gap="4">
+        {registry.map((item) => (
+          <Card key={item.id} variant="surface">
+            <Flex direction="column" gap="3">
+              <Heading size="4">{item.title}</Heading>
+              <Text size="2" color="gray">
+                {item.summary}
+              </Text>
+              <Flex gap="3" align="center" wrap="wrap">
+                <Text size="2" weight="medium">
+                  {t("registry.slug", { slug: item.slug })}
+                </Text>
+                <Text size="2" color="gray">
+                  {t("registry.category", { category: item.category })}
+                </Text>
+                <Text size="2" color="gray">
+                  {t("registry.latest", { version: item.latestVersion })}
+                </Text>
+                <Text size="2" color="gray">
+                  {t("registry.published", { count: item.publishedVersions })}
+                </Text>
+              </Flex>
+            </Flex>
+          </Card>
+        ))}
+      </Grid>
+
+      <Card variant="surface">
+        <Flex direction="column" gap="4">
+          <header>
+            <Heading size="5">{t("versions.title")}</Heading>
+            <Text size="2" color="gray">
+              {t("versions.subtitle")}
+            </Text>
+          </header>
+          <DataTable
+            caption={t("versions.caption")}
+            emptyState={t("versions.empty")}
+            columns={[
+              { key: "stepType", header: t("versions.columns.stepType") },
+              { key: "version", header: t("versions.columns.version") },
+              {
+                key: "status",
+                header: t("versions.columns.status"),
+                render: (value) => (
+                  <span className="inline-flex rounded-full bg-emerald-100 px-2 py-1 text-xs font-medium text-emerald-800">
+                    {t(`versions.status.${String(value)}`)}
+                  </span>
+                ),
+              },
+              { key: "schemaSlug", header: t("versions.columns.schema") },
+              { key: "publishedAt", header: t("versions.columns.publishedAt") },
+            ]}
+            data={versionLedger}
+          />
+        </Flex>
+      </Card>
+
+      <Grid columns={{ initial: "1", md: "2" }} gap="4">
+        <Card variant="surface">
+          <Flex direction="column" gap="4">
+            <header>
+              <Heading size="5">{t("installs.title")}</Heading>
+              <Text size="2" color="gray">{t("installs.subtitle")}</Text>
+            </header>
+            <DataTable
+              caption={t("installs.caption")}
+              emptyState={t("installs.empty")}
+              columns={[
+                { key: "tenant", header: t("installs.columns.tenant") },
+                { key: "stepTypeVersion", header: t("installs.columns.version") },
+                {
+                  key: "status",
+                  header: t("installs.columns.status"),
+                  render: (value) => (
+                    <span className="inline-flex rounded-full bg-blue-100 px-2 py-1 text-xs font-medium text-blue-800">
+                      {t(`installs.status.${String(value)}`)}
+                    </span>
+                  ),
+                },
+                { key: "installedAt", header: t("installs.columns.installedAt") },
+              ]}
+              data={tenantInstalls}
+            />
+          </Flex>
+        </Card>
+
+        <Card variant="surface">
+          <Flex direction="column" gap="4">
+            <header>
+              <Heading size="5">{t("secrets.title")}</Heading>
+              <Text size="2" color="gray">{t("secrets.subtitle")}</Text>
+            </header>
+            <DataTable
+              caption={t("secrets.caption")}
+              emptyState={t("secrets.empty")}
+              columns={[
+                { key: "tenant", header: t("secrets.columns.tenant") },
+                { key: "alias", header: t("secrets.columns.alias") },
+                { key: "provider", header: t("secrets.columns.provider") },
+                { key: "externalId", header: t("secrets.columns.externalId") },
+              ]}
+              data={secretBindings}
+            />
+          </Flex>
+        </Card>
+      </Grid>
+
+      <Card variant="surface">
+        <Flex direction="column" gap="4">
+          <header>
+            <Heading size="5">{t("overlays.title")}</Heading>
+            <Text size="2" color="gray">{t("overlays.subtitle")}</Text>
+          </header>
+          <DataTable
+            caption={t("overlays.caption")}
+            emptyState={t("overlays.empty")}
+            columns={[
+              { key: "workflow", header: t("overlays.columns.workflow") },
+              { key: "tenant", header: t("overlays.columns.tenant") },
+              { key: "overlays", header: t("overlays.columns.count") },
+              { key: "createdAt", header: t("overlays.columns.createdAt") },
+            ]}
+            data={overlayActivity}
+          />
+        </Flex>
+      </Card>
+    </Flex>
+  );
+}

--- a/apps/portal/messages/en-IE/common.json
+++ b/apps/portal/messages/en-IE/common.json
@@ -127,5 +127,59 @@
     "redirect": "After sign-in you'll be sent to {destination}.",
     "error": "We couldn't send the link. Please try again.",
     "supabaseUnavailable": "Supabase configuration is missing. Set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY to enable sign-in."
+  },
+  "overlayBuilder": {
+    "heading": "Tenant overlay builder",
+    "description": "Compose JSON Patch overlays with registry-backed steps and preview impact before publishing.",
+    "base": {
+      "heading": "Base workflow",
+      "hint": "These are the core steps before tenant overlays are applied.",
+      "optional": "Optional base step"
+    },
+    "add": {
+      "heading": "Add registry step",
+      "hint": "Select an approved step type, provide input defaults, and bind secret aliases.",
+      "stepType": "Step type",
+      "input": "Input JSON",
+      "inputPlaceholder": "{ } // JSON payload for the step",
+      "secret": "Secret alias",
+      "secretPlaceholder": "Select alias (optional)"
+    },
+    "actions": {
+      "insert": "Insert step",
+      "reset": "Clear overlay",
+      "persist": "Persist overlay snapshot"
+    },
+    "operations": {
+      "heading": "Overlay operations (JSON Patch)"
+    },
+    "overlay": {
+      "heading": "Overlay impact",
+      "hint": "Review step additions/removals before publishing.",
+      "count": "{count, plural, one {# overlay operation} other {# overlay operations}}",
+      "added": "Added steps",
+      "removed": "Removed steps"
+    },
+    "messages": {
+      "persistSuccess": "Overlay snapshot queued for persistence.",
+      "persistError": "Unable to persist overlay snapshot.",
+      "mergeError": "Overlay merge failed",
+      "secretRequired": "Select a secret alias before inserting this step.",
+      "secretUnavailable": "No eligible secret bindings are available for this step type."
+    },
+    "stepTypes": {
+      "manualReview": {
+        "title": "Manual review (dual control)",
+        "summary": "Collect reviewer notes and capture evidence before approving the step."
+      },
+      "temporalWebhook": {
+        "title": "Temporal webhook bridge",
+        "summary": "Trigger a tenant-specific Temporal workflow via signed webhook requests."
+      }
+    },
+    "secrets": {
+      "crmApiToken": "CRM API token resolved at runtime.",
+      "temporalQueue": "Temporal task queue signing key stored in vault."
+    }
   }
 }

--- a/apps/portal/messages/ga-IE/common.json
+++ b/apps/portal/messages/ga-IE/common.json
@@ -127,5 +127,59 @@
     "redirect": "Tar éis duit síniú isteach seolfar tú go {destination}.",
     "error": "Níor éirigh linn an nasc a sheoladh. Bain triail eile as.",
     "supabaseUnavailable": "Tá cumraíocht Supabase ar iarraidh. Socraigh NEXT_PUBLIC_SUPABASE_URL agus NEXT_PUBLIC_SUPABASE_ANON_KEY chun an síniú isteach a chumasú."
+  },
+  "overlayBuilder": {
+    "heading": "Tógálaí forleagain tionant",
+    "description": "Cum forleagain JSON Patch le céimeanna ón gclárlann agus féach ar an tionchar roimh fhoilsiú.",
+    "base": {
+      "heading": "Sreabhadh bunúsach",
+      "hint": "Seo iad na céimeanna croí sula gcuirtear forleagain tionant i bhfeidhm.",
+      "optional": "Céim bhunúsach roghnach"
+    },
+    "add": {
+      "heading": "Cuir céim ón gclárlann leis",
+      "hint": "Roghnaigh cineál céime formheasta, soláthair ionchuir réamhshocraithe, agus ceangail ailiasanna rúin.",
+      "stepType": "Cineál céime",
+      "input": "JSON ionchuir",
+      "inputPlaceholder": "{ } // Lódál JSON don chéim",
+      "secret": "Ailias rúin",
+      "secretPlaceholder": "Roghnaigh ailias (roghnach)"
+    },
+    "actions": {
+      "insert": "Cuir céim isteach",
+      "reset": "Glan forleagan",
+      "persist": "Seachad snapshot forleagain"
+    },
+    "operations": {
+      "heading": "Oibríochtaí forleagain (JSON Patch)"
+    },
+    "overlay": {
+      "heading": "Tionchar an fhorleagain",
+      "hint": "Athbhreithnigh céimeanna curtha leis nó bainte sula bhfoilseofar.",
+      "count": "{count, plural, one {# oibríocht forleagain} other {# oibríochtaí forleagain}}",
+      "added": "Céimeanna curtha leis",
+      "removed": "Céimeanna bainte"
+    },
+    "messages": {
+      "persistSuccess": "Cuireadh snapshot forleagain i scuaine le sábháil.",
+      "persistError": "Níor éirigh le snapshot forleagain a shábháil.",
+      "mergeError": "Theip ar chumasc forleagain",
+      "secretRequired": "Roghnaigh ailias rúin sula gcuirtear an chéim seo isteach.",
+      "secretUnavailable": "Níl aon cheangail rúin oiriúnacha ar fáil don chineál céime seo."
+    },
+    "stepTypes": {
+      "manualReview": {
+        "title": "Athbhreithniú láimhe (rialú dúbailte)",
+        "summary": "Bailigh nótaí athbhreithnitheora agus fianaise sula gceadaítear an chéim."
+      },
+      "temporalWebhook": {
+        "title": "Droichead webhook Temporal",
+        "summary": "Cuir sreabhadh Temporal an tionant ar siúl trí iarrataí webhook sínithe."
+      }
+    },
+    "secrets": {
+      "crmApiToken": "Comhartha API CRM réitithe ag am rith.",
+      "temporalQueue": "Eochair scuaine tasc Temporal stóráilte sa stór rúin."
+    }
   }
 }

--- a/apps/portal/src/app/[locale]/(workflow)/overlay-builder/page.tsx
+++ b/apps/portal/src/app/[locale]/(workflow)/overlay-builder/page.tsx
@@ -1,0 +1,114 @@
+import path from "node:path";
+import { getTranslations } from "next-intl/server";
+import { loadDSL } from "@airnub/engine/dsl";
+import { materializeWorkflow } from "@airnub/engine/engine";
+import { TenantOverlayBuilder } from "../../../../components/tenant-overlay-builder";
+
+export default async function OverlayBuilderPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "overlayBuilder" });
+
+  const workflowPath = path.join(
+    process.cwd(),
+    "packages",
+    "workflows",
+    "ie-nonprofit-clg-charity.yaml"
+  );
+  const dsl = loadDSL(workflowPath);
+  const materialized = materializeWorkflow(dsl);
+
+  const baseWorkflow = {
+    id: dsl.id,
+    version: dsl.version,
+    title: dsl.title,
+    steps: materialized.steps.map((step) => ({
+      id: step.id,
+      title: step.title,
+      kind: step.kind,
+      required: step.required,
+      stepType: step.stepType,
+    })),
+  };
+
+  const stepTypes = [
+    {
+      slug: "manual.review",
+      version: "2.1.0",
+      title: t("stepTypes.manualReview.title"),
+      summary: t("stepTypes.manualReview.summary"),
+      kind: "review",
+      executionMode: "manual" as const,
+      defaultInput: {
+        checklist: ["evidence", "notes"],
+      },
+      secretAliases: [],
+    },
+    {
+      slug: "temporal.webhook",
+      version: "1.4.0",
+      title: t("stepTypes.temporalWebhook.title"),
+      summary: t("stepTypes.temporalWebhook.summary"),
+      kind: "tool.call",
+      executionMode: "temporal" as const,
+      defaultInput: {
+        urlAlias: "secrets.crm.apiToken",
+        retryPolicy: { attempts: 3 },
+      },
+      secretAliases: ["secrets.crm.apiToken", "secrets.temporal.taskQueueKey"],
+    },
+  ];
+
+  const secrets = [
+    {
+      alias: "secrets.crm.apiToken",
+      description: t("secrets.crmApiToken"),
+    },
+    {
+      alias: "secrets.temporal.taskQueueKey",
+      description: t("secrets.temporalQueue"),
+    },
+  ];
+
+  const labels = {
+    heading: t("heading"),
+    description: t("description"),
+    baseHeading: t("base.heading"),
+    baseHint: t("base.hint"),
+    addHeading: t("add.heading"),
+    addHint: t("add.hint"),
+    stepTypeLabel: t("add.stepType"),
+    inputLabel: t("add.input"),
+    inputPlaceholder: t("add.inputPlaceholder"),
+    secretLabel: t("add.secret"),
+    secretPlaceholder: t("add.secretPlaceholder"),
+    insertButton: t("actions.insert"),
+    resetButton: t("actions.reset"),
+    operationsHeading: t("operations.heading"),
+    overlayHeading: t("overlay.heading"),
+    overlayHint: t("overlay.hint"),
+    persistButton: t("actions.persist"),
+    persistSuccess: t("messages.persistSuccess"),
+    persistError: t("messages.persistError"),
+    mergeError: t("messages.mergeError"),
+    secretRequired: t("messages.secretRequired"),
+    secretUnavailable: t("messages.secretUnavailable"),
+    addedLabel: t("overlay.added"),
+    removedLabel: t("overlay.removed"),
+    totalLabel: t("base.optional"),
+    overlayCount: (count: number) => t("overlay.count", { count }),
+  } as const;
+
+  return (
+    <TenantOverlayBuilder
+      baseWorkflow={baseWorkflow}
+      stepTypes={stepTypes}
+      secrets={secrets}
+      tenantId="tenant-company-x"
+      labels={labels}
+    />
+  );
+}

--- a/apps/portal/src/app/api/overlays/route.ts
+++ b/apps/portal/src/app/api/overlays/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import {
+  getSupabaseClient,
+  SupabaseConfigurationError,
+} from "../../../server/supabase";
+
+export async function POST(request: Request) {
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch (error) {
+    return NextResponse.json(
+      { ok: false, error: "Invalid JSON payload" },
+      { status: 400 }
+    );
+  }
+
+  if (!payload || typeof payload !== "object") {
+    return NextResponse.json(
+      { ok: false, error: "Request body must be an object" },
+      { status: 400 }
+    );
+  }
+
+  const { tenantId, workflowId, overlay, mergedWorkflow } = payload as {
+    tenantId?: string;
+    workflowId?: string;
+    overlay?: unknown;
+    mergedWorkflow?: unknown;
+  };
+
+  if (!tenantId || !workflowId || !Array.isArray(overlay) || !mergedWorkflow) {
+    return NextResponse.json(
+      { ok: false, error: "Missing tenantId, workflowId, overlay, or mergedWorkflow" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const supabase = getSupabaseClient();
+    const { error } = await supabase.from("workflow_overlay_snapshots").insert({
+      run_id: null,
+      tenant_overlay_id: null,
+      applied_overlays: overlay,
+      merged_workflow: mergedWorkflow,
+    });
+
+    if (error) {
+      return NextResponse.json(
+        { ok: false, error: error.message },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    if (error instanceof SupabaseConfigurationError) {
+      return NextResponse.json(
+        { ok: false, error: error.message },
+        { status: 503 }
+      );
+    }
+    return NextResponse.json(
+      { ok: false, error: (error as Error).message },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/portal/src/components/tenant-overlay-builder.tsx
+++ b/apps/portal/src/components/tenant-overlay-builder.tsx
@@ -1,0 +1,517 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { applyPatch, type Operation } from "fast-json-patch";
+import {
+  Button,
+  Card,
+  Callout,
+  Flex,
+  Grid,
+  Heading,
+  Select,
+  Separator,
+  Text,
+  TextArea
+} from "@radix-ui/themes";
+
+export type OverlayStepType = {
+  slug: string;
+  version: string;
+  title: string;
+  summary: string;
+  kind: string;
+  executionMode: "manual" | "temporal";
+  defaultInput: Record<string, unknown>;
+  secretAliases: string[];
+};
+
+export type OverlaySecretBinding = {
+  alias: string;
+  description: string;
+};
+
+export type OverlayWorkflow = {
+  id: string;
+  version: string;
+  title?: string;
+  steps: Array<{
+    id: string;
+    title: string;
+    kind: string;
+    required?: boolean;
+    stepType?: string;
+  }>;
+};
+
+export interface OverlayBuilderLabels {
+  heading: string;
+  description: string;
+  baseHeading: string;
+  baseHint: string;
+  addHeading: string;
+  addHint: string;
+  stepTypeLabel: string;
+  inputLabel: string;
+  inputPlaceholder: string;
+  secretLabel: string;
+  secretPlaceholder: string;
+  insertButton: string;
+  resetButton: string;
+  operationsHeading: string;
+  overlayHeading: string;
+  overlayHint: string;
+  persistButton: string;
+  persistSuccess: string;
+  persistError: string;
+  mergeError: string;
+  secretRequired: string;
+  secretUnavailable: string;
+  addedLabel: string;
+  removedLabel: string;
+  totalLabel: string;
+  overlayCount: (count: number) => string;
+}
+
+export interface TenantOverlayBuilderProps {
+  baseWorkflow: OverlayWorkflow;
+  stepTypes: OverlayStepType[];
+  secrets: OverlaySecretBinding[];
+  tenantId: string;
+  labels: OverlayBuilderLabels;
+}
+
+export function TenantOverlayBuilder({
+  baseWorkflow,
+  stepTypes,
+  secrets,
+  tenantId,
+  labels
+}: TenantOverlayBuilderProps) {
+  const [selectedStepType, setSelectedStepType] = useState(() =>
+    stepTypes.length > 0 ? `${stepTypes[0].slug}@${stepTypes[0].version}` : ""
+  );
+  const [inputJson, setInputJson] = useState(() =>
+    JSON.stringify(stepTypes[0]?.defaultInput ?? {}, null, 2)
+  );
+  const [selectedSecret, setSelectedSecret] = useState<string>(
+    secrets[0]?.alias ?? ""
+  );
+  const [inputError, setInputError] = useState<string | null>(null);
+  const [secretError, setSecretError] = useState<string | null>(null);
+  const [overlayOperations, setOverlayOperations] = useState<Operation[]>([]);
+  const [persistMessage, setPersistMessage] = useState<string | null>(null);
+  const [persistError, setPersistError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const mergeResult = useMemo(() => {
+    try {
+      const result = applyPatch(structuredClone(baseWorkflow), overlayOperations, true, false);
+      return {
+        workflow: (result.newDocument as OverlayWorkflow) ?? baseWorkflow,
+        error: null as string | null
+      };
+    } catch (error) {
+      return { workflow: baseWorkflow, error: (error as Error).message };
+    }
+  }, [baseWorkflow, overlayOperations]);
+
+  const mergedWorkflow = mergeResult.workflow;
+  const mergeError = mergeResult.error;
+
+  const impact = useMemo(() => {
+    const baseIds = new Set(baseWorkflow.steps.map((step) => step.id));
+    const mergedIds = new Set(mergedWorkflow.steps.map((step) => step.id));
+    const added = Array.from(mergedIds).filter((id) => !baseIds.has(id));
+    const removed = Array.from(baseIds).filter((id) => !mergedIds.has(id));
+    return { added, removed };
+  }, [baseWorkflow.steps, mergedWorkflow.steps]);
+
+  const overlayJson = useMemo(
+    () => JSON.stringify(overlayOperations, null, 2),
+    [overlayOperations]
+  );
+
+  const activeStepType = useMemo(() => {
+    const [slug, version] = selectedStepType.split("@");
+    return stepTypes.find(
+      (candidate) => candidate.slug === slug && candidate.version === version
+    );
+  }, [selectedStepType, stepTypes]);
+
+  const availableSecrets = useMemo(() => {
+    if (!activeStepType || activeStepType.secretAliases.length === 0) {
+      return secrets;
+    }
+    return secrets.filter((secret) =>
+      activeStepType.secretAliases.includes(secret.alias)
+    );
+  }, [activeStepType, secrets]);
+
+  useEffect(() => {
+    if (!activeStepType) {
+      setSecretError(null);
+      return;
+    }
+
+    if (activeStepType.secretAliases.length === 0) {
+      if (selectedSecret) {
+        setSelectedSecret("");
+      }
+      setSecretError(null);
+      return;
+    }
+
+    if (availableSecrets.length === 0) {
+      if (selectedSecret) {
+        setSelectedSecret("");
+      }
+      setSecretError(labels.secretUnavailable);
+      return;
+    }
+
+    const hasValidSelection = availableSecrets.some(
+      (secret) => secret.alias === selectedSecret
+    );
+
+    if (!hasValidSelection) {
+      const fallback = availableSecrets[0]?.alias ?? "";
+      setSelectedSecret(fallback);
+    }
+
+    setSecretError(null);
+  }, [activeStepType, availableSecrets, labels.secretUnavailable, selectedSecret]);
+
+  const handleSecretChange = (value: string) => {
+    setSelectedSecret(value);
+    setSecretError(null);
+  };
+
+  const handleInsertStep = () => {
+    if (!selectedStepType) {
+      return;
+    }
+    const [slug, version] = selectedStepType.split("@");
+    const stepType = stepTypes.find(
+      (candidate) => candidate.slug === slug && candidate.version === version
+    );
+    if (!stepType) {
+      return;
+    }
+
+    if (
+      stepType.secretAliases.length > 0 &&
+      (!selectedSecret || !stepType.secretAliases.includes(selectedSecret))
+    ) {
+      setSecretError(
+        availableSecrets.length === 0
+          ? labels.secretUnavailable
+          : labels.secretRequired
+      );
+      return;
+    }
+
+    let parsedInput: Record<string, unknown> = {};
+    if (inputJson.trim().length > 0) {
+      try {
+        parsedInput = JSON.parse(inputJson);
+        setInputError(null);
+      } catch (error) {
+        setInputError((error as Error).message);
+        return;
+      }
+    } else {
+      setInputError(null);
+    }
+
+    const timestamp = Date.now();
+    const stepId = `${slug}-${version}-${timestamp}`;
+    const secretsMetadata = selectedSecret
+      ? { secrets: { primary: { alias: selectedSecret } } }
+      : undefined;
+
+    const operation: Operation = {
+      op: "add",
+      path: "/steps/-",
+      value: {
+        id: stepId,
+        kind: stepType.kind,
+        title: stepType.title,
+        stepType: `${slug}@${version}`,
+        execution: {
+          mode: stepType.executionMode,
+        },
+        input: parsedInput,
+        metadata: secretsMetadata,
+      },
+    };
+
+    setOverlayOperations((prev) => [...prev, operation]);
+    setSecretError(null);
+    setPersistMessage(null);
+    setPersistError(null);
+  };
+
+  const handleReset = () => {
+    setOverlayOperations([]);
+    setPersistMessage(null);
+    setPersistError(null);
+    setSecretError(null);
+  };
+
+  const handlePersist = async () => {
+    if (mergeError) {
+      setPersistMessage(null);
+      setPersistError(`${labels.mergeError}: ${mergeError}`);
+      return;
+    }
+
+    setIsSaving(true);
+    setPersistMessage(null);
+    setPersistError(null);
+    try {
+      const response = await fetch("/api/overlays", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          tenantId,
+          workflowId: baseWorkflow.id,
+          overlay: overlayOperations,
+          mergedWorkflow,
+        }),
+      });
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}));
+        throw new Error(payload.error ?? labels.persistError);
+      }
+      setPersistMessage(labels.persistSuccess);
+    } catch (error) {
+      setPersistError((error as Error).message);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const stepTypeItems = stepTypes.map((type) => ({
+    value: `${type.slug}@${type.version}`,
+    label: `${type.title} (${type.version})`,
+  }));
+
+  return (
+    <Flex direction="column" gap="5">
+      <Card variant="surface">
+        <Flex direction="column" gap="3">
+          <Heading size="6">{labels.heading}</Heading>
+          <Text size="3" color="gray">
+            {labels.description}
+          </Text>
+        </Flex>
+      </Card>
+
+      <Grid columns={{ initial: "1", md: "2" }} gap="4">
+        <Card variant="surface">
+          <Flex direction="column" gap="3">
+            <Heading size="5">{labels.baseHeading}</Heading>
+            <Text size="2" color="gray">
+              {labels.baseHint}
+            </Text>
+            <Separator my="2" size="4" />
+            <Flex direction="column" gap="2">
+              {baseWorkflow.steps.map((step) => (
+                <Flex key={step.id} direction="column" gap="1" className="rounded-md border border-gray-200 p-3">
+                  <Text size="3" weight="medium">
+                    {step.title}
+                  </Text>
+                  <Text size="2" color="gray">
+                    {step.stepType ?? step.kind}
+                  </Text>
+                  <Text size="1" color="gray">
+                    {step.required ? labels.addedLabel : labels.totalLabel}
+                  </Text>
+                </Flex>
+              ))}
+            </Flex>
+          </Flex>
+        </Card>
+
+        <Card variant="surface">
+          <Flex direction="column" gap="4">
+            <header>
+              <Heading size="5">{labels.addHeading}</Heading>
+              <Text size="2" color="gray">{labels.addHint}</Text>
+            </header>
+            <Flex direction="column" gap="3">
+              <label className="space-y-2">
+                <Text size="2" weight="medium">
+                  {labels.stepTypeLabel}
+                </Text>
+                <Select.Root value={selectedStepType} onValueChange={setSelectedStepType}>
+                  <Select.Trigger className="w-full" />
+                  <Select.Content>
+                    {stepTypeItems.map((item) => (
+                      <Select.Item key={item.value} value={item.value}>
+                        {item.label}
+                      </Select.Item>
+                    ))}
+                  </Select.Content>
+                </Select.Root>
+                {activeStepType ? (
+                  <Text size="1" color="gray">
+                    {activeStepType.summary}
+                  </Text>
+                ) : null}
+              </label>
+
+              <label className="space-y-2">
+                <Text size="2" weight="medium">
+                  {labels.inputLabel}
+                </Text>
+                <TextArea
+                  value={inputJson}
+                  onChange={(event) => setInputJson(event.target.value)}
+                  rows={6}
+                  placeholder={labels.inputPlaceholder}
+                />
+                {inputError ? (
+                  <Text size="1" color="red">
+                    {inputError}
+                  </Text>
+                ) : null}
+              </label>
+
+              <label className="space-y-2">
+                <Text size="2" weight="medium">
+                  {labels.secretLabel}
+                </Text>
+                <Select.Root
+                  value={selectedSecret}
+                  onValueChange={handleSecretChange}
+                >
+                  <Select.Trigger
+                    className="w-full"
+                    placeholder={labels.secretPlaceholder}
+                    disabled={
+                      !!activeStepType &&
+                      activeStepType.secretAliases.length > 0 &&
+                      availableSecrets.length === 0
+                    }
+                  />
+                  <Select.Content>
+                    <Select.Item
+                      value=""
+                      disabled={
+                        !!activeStepType && activeStepType.secretAliases.length > 0
+                      }
+                    >
+                      {labels.secretPlaceholder}
+                    </Select.Item>
+                    {availableSecrets.map((secret) => (
+                      <Select.Item key={secret.alias} value={secret.alias}>
+                        {secret.alias}
+                      </Select.Item>
+                    ))}
+                  </Select.Content>
+                </Select.Root>
+                {secretError ? (
+                  <Text size="1" color="red">{secretError}</Text>
+                ) : selectedSecret ? (
+                  <Text size="1" color="gray">
+                    {secrets.find((secret) => secret.alias === selectedSecret)?.description}
+                  </Text>
+                ) : null}
+              </label>
+
+              <Flex gap="3" wrap="wrap">
+                <Button onClick={handleInsertStep}>{labels.insertButton}</Button>
+                <Button variant="soft" color="gray" onClick={handleReset} disabled={overlayOperations.length === 0}>
+                  {labels.resetButton}
+                </Button>
+              </Flex>
+            </Flex>
+          </Flex>
+        </Card>
+      </Grid>
+
+      <Card variant="surface">
+        <Flex direction="column" gap="3">
+          <Heading size="5">{labels.operationsHeading}</Heading>
+          <TextArea value={overlayJson} rows={12} readOnly />
+        </Flex>
+      </Card>
+
+      <Card variant="surface">
+        <Flex direction="column" gap="3">
+          <Heading size="5">{labels.overlayHeading}</Heading>
+          <Text size="2" color="gray">
+            {labels.overlayHint}
+          </Text>
+          <Text size="2" weight="medium">
+            {labels.overlayCount(overlayOperations.length)}
+          </Text>
+          {mergeError ? (
+            <Callout.Root color="red">
+              <Callout.Text>{labels.mergeError}: {mergeError}</Callout.Text>
+            </Callout.Root>
+          ) : null}
+          <Grid columns={{ initial: "1", md: "2" }} gap="3">
+            <Card variant="classic">
+              <Flex direction="column" gap="2">
+                <Text size="2" weight="medium">
+                  {labels.addedLabel}
+                </Text>
+                {impact.added.length === 0 ? (
+                  <Text size="1" color="gray">
+                    —
+                  </Text>
+                ) : (
+                  impact.added.map((id) => (
+                    <Text key={id} size="2">
+                      {id}
+                    </Text>
+                  ))
+                )}
+              </Flex>
+            </Card>
+            <Card variant="classic">
+              <Flex direction="column" gap="2">
+                <Text size="2" weight="medium">
+                  {labels.removedLabel}
+                </Text>
+                {impact.removed.length === 0 ? (
+                  <Text size="1" color="gray">
+                    —
+                  </Text>
+                ) : (
+                  impact.removed.map((id) => (
+                    <Text key={id} size="2">
+                      {id}
+                    </Text>
+                  ))
+                )}
+              </Flex>
+            </Card>
+          </Grid>
+          <Separator my="2" size="4" />
+          <Flex gap="3" wrap="wrap">
+            <Button
+              onClick={handlePersist}
+              disabled={overlayOperations.length === 0 || isSaving || Boolean(mergeError)}
+            >
+              {labels.persistButton}
+            </Button>
+            {persistMessage ? (
+              <Callout.Root color="green">
+                <Callout.Text>{persistMessage}</Callout.Text>
+              </Callout.Root>
+            ) : null}
+            {persistError ? (
+              <Callout.Root color="red">
+                <Callout.Text>{persistError}</Callout.Text>
+              </Callout.Root>
+            ) : null}
+          </Flex>
+        </Flex>
+      </Card>
+    </Flex>
+  );
+}

--- a/packages/db/migrations/202501120001_overlay_model.sql
+++ b/packages/db/migrations/202501120001_overlay_model.sql
@@ -1,0 +1,183 @@
+alter table workflow_runs
+  add column if not exists merged_workflow_snapshot jsonb;
+
+alter table steps
+  add column if not exists step_type_version_id uuid,
+  add column if not exists permissions text[] default '{}'::text[];
+
+create table if not exists json_schemas(
+  id uuid primary key default gen_random_uuid(),
+  slug text unique not null,
+  version text not null,
+  description text,
+  schema jsonb not null,
+  created_at timestamptz default now()
+);
+
+create table if not exists step_types(
+  id uuid primary key default gen_random_uuid(),
+  slug text unique not null,
+  title text not null,
+  category text,
+  summary text,
+  latest_version text,
+  created_by uuid references users(id),
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create table if not exists step_type_versions(
+  id uuid primary key default gen_random_uuid(),
+  step_type_id uuid references step_types(id) on delete cascade,
+  version text not null,
+  definition jsonb not null,
+  input_schema_id uuid references json_schemas(id),
+  output_schema_id uuid references json_schemas(id),
+  status text check (status in ('draft','published','deprecated')) default 'draft',
+  created_by uuid references users(id),
+  created_at timestamptz default now(),
+  published_at timestamptz,
+  unique(step_type_id, version)
+);
+
+alter table steps
+  add constraint if not exists steps_step_type_version_id_fkey
+  foreign key (step_type_version_id)
+  references step_type_versions(id);
+
+create table if not exists tenant_step_type_installs(
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid references organisations(id) on delete cascade,
+  step_type_version_id uuid references step_type_versions(id) on delete cascade,
+  installed_at timestamptz default now(),
+  status text check (status in ('enabled','disabled')) default 'enabled',
+  unique(org_id, step_type_version_id)
+);
+
+create table if not exists tenant_secret_bindings(
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid references organisations(id) on delete cascade,
+  alias text not null,
+  description text,
+  provider text,
+  external_id text not null,
+  created_at timestamptz default now(),
+  unique(org_id, alias)
+);
+
+create table if not exists tenant_workflow_overlays(
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid references organisations(id) on delete cascade,
+  workflow_def_id uuid references workflow_defs(id) on delete cascade,
+  title text not null,
+  patch jsonb not null,
+  status text check (status in ('draft','published','archived')) default 'draft',
+  created_by uuid references users(id),
+  updated_at timestamptz default now(),
+  created_at timestamptz default now(),
+  unique(org_id, workflow_def_id, title)
+);
+
+create table if not exists workflow_overlay_snapshots(
+  id uuid primary key default gen_random_uuid(),
+  run_id uuid references workflow_runs(id) on delete cascade,
+  tenant_overlay_id uuid references tenant_workflow_overlays(id),
+  applied_overlays jsonb not null default '[]'::jsonb,
+  merged_workflow jsonb not null,
+  created_at timestamptz default now()
+);
+
+create table if not exists workflow_overlay_layers(
+  id uuid primary key default gen_random_uuid(),
+  snapshot_id uuid references workflow_overlay_snapshots(id) on delete cascade,
+  source text not null,
+  patch jsonb not null,
+  created_at timestamptz default now()
+);
+
+alter table json_schemas enable row level security;
+alter table step_types enable row level security;
+alter table step_type_versions enable row level security;
+alter table tenant_step_type_installs enable row level security;
+alter table tenant_secret_bindings enable row level security;
+alter table tenant_workflow_overlays enable row level security;
+alter table workflow_overlay_snapshots enable row level security;
+alter table workflow_overlay_layers enable row level security;
+
+create policy if not exists "Service role manages json schemas" on json_schemas
+  for all using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy if not exists "Admins read json schemas" on json_schemas
+  for select using (auth.role() in ('service_role', 'authenticated'));
+
+create policy if not exists "Service role manages step types" on step_types
+  for all using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy if not exists "Admins read step types" on step_types
+  for select using (auth.role() in ('service_role', 'authenticated'));
+
+create policy if not exists "Service role manages step type versions" on step_type_versions
+  for all using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy if not exists "Admins read step type versions" on step_type_versions
+  for select using (auth.role() in ('service_role', 'authenticated'));
+
+create policy if not exists "Service role manages tenant installs" on tenant_step_type_installs
+  for all using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy if not exists "Tenant members read installs" on tenant_step_type_installs
+  for select using (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(org_id)
+  );
+
+create policy if not exists "Service role manages tenant secret bindings" on tenant_secret_bindings
+  for all using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy if not exists "Tenant members manage secret bindings" on tenant_secret_bindings
+  for select using (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(org_id)
+  );
+
+create policy if not exists "Service role manages tenant overlays" on tenant_workflow_overlays
+  for all using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy if not exists "Tenant members manage overlays" on tenant_workflow_overlays
+  for select using (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(org_id)
+  )
+  with check (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(org_id)
+  );
+
+create policy if not exists "Service role manages overlay snapshots" on workflow_overlay_snapshots
+  for all using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy if not exists "Members read overlay snapshots" on workflow_overlay_snapshots
+  for select using (
+    auth.role() = 'service_role'
+    or (run_id is not null and public.can_access_run(run_id))
+  );
+
+create policy if not exists "Service role manages overlay layers" on workflow_overlay_layers
+  for all using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy if not exists "Members read overlay layers" on workflow_overlay_layers
+  for select using (
+    auth.role() = 'service_role'
+    or exists (
+      select 1 from workflow_overlay_snapshots s
+      where s.id = snapshot_id and public.can_access_run(s.run_id)
+    )
+  );

--- a/packages/db/schema.sql
+++ b/packages/db/schema.sql
@@ -46,6 +46,7 @@ create table workflow_runs(
   orchestration_provider text not null default 'none',
   orchestration_workflow_id text,
   created_by_user_id uuid references users(id),
+  merged_workflow_snapshot jsonb,
   created_at timestamptz default now()
 );
 
@@ -58,7 +59,99 @@ create table steps(
   orchestration_run_id text,
   execution_mode text check (execution_mode in ('manual','temporal')) not null default 'manual',
   due_date date,
-  assignee_user_id uuid references users(id)
+  assignee_user_id uuid references users(id),
+  step_type_version_id uuid,
+  permissions text[] default '{}'::text[]
+);
+
+create table json_schemas(
+  id uuid primary key default gen_random_uuid(),
+  slug text unique not null,
+  version text not null,
+  description text,
+  schema jsonb not null,
+  created_at timestamptz default now()
+);
+
+create table step_types(
+  id uuid primary key default gen_random_uuid(),
+  slug text unique not null,
+  title text not null,
+  category text,
+  summary text,
+  latest_version text,
+  created_by uuid references users(id),
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create table step_type_versions(
+  id uuid primary key default gen_random_uuid(),
+  step_type_id uuid references step_types(id) on delete cascade,
+  version text not null,
+  definition jsonb not null,
+  input_schema_id uuid references json_schemas(id),
+  output_schema_id uuid references json_schemas(id),
+  status text check (status in ('draft','published','deprecated')) default 'draft',
+  created_by uuid references users(id),
+  created_at timestamptz default now(),
+  published_at timestamptz,
+  unique(step_type_id, version)
+);
+
+alter table steps
+  add constraint steps_step_type_version_id_fkey
+  foreign key (step_type_version_id)
+  references step_type_versions(id);
+
+create table tenant_step_type_installs(
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid references organisations(id) on delete cascade,
+  step_type_version_id uuid references step_type_versions(id) on delete cascade,
+  installed_at timestamptz default now(),
+  status text check (status in ('enabled','disabled')) default 'enabled',
+  unique(org_id, step_type_version_id)
+);
+
+create table tenant_secret_bindings(
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid references organisations(id) on delete cascade,
+  alias text not null,
+  description text,
+  provider text,
+  external_id text not null,
+  created_at timestamptz default now(),
+  unique(org_id, alias)
+);
+
+create table tenant_workflow_overlays(
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid references organisations(id) on delete cascade,
+  workflow_def_id uuid references workflow_defs(id) on delete cascade,
+  title text not null,
+  patch jsonb not null,
+  status text check (status in ('draft','published','archived')) default 'draft',
+  created_by uuid references users(id),
+  updated_at timestamptz default now(),
+  created_at timestamptz default now(),
+  unique(org_id, workflow_def_id, title)
+);
+
+create table workflow_overlay_snapshots(
+  id uuid primary key default gen_random_uuid(),
+  run_id uuid references workflow_runs(id) on delete cascade,
+  tenant_overlay_id uuid references tenant_workflow_overlays(id),
+  applied_overlays jsonb not null default '[]'::jsonb,
+  merged_workflow jsonb not null,
+  created_at timestamptz default now()
+);
+
+create table workflow_overlay_layers(
+  id uuid primary key default gen_random_uuid(),
+  snapshot_id uuid references workflow_overlay_snapshots(id) on delete cascade,
+  source text not null,
+  patch jsonb not null,
+  created_at timestamptz default now()
 );
 
 create table documents(
@@ -119,6 +212,14 @@ alter table workflow_runs enable row level security;
 alter table steps enable row level security;
 alter table documents enable row level security;
 alter table audit_log enable row level security;
+alter table json_schemas enable row level security;
+alter table step_types enable row level security;
+alter table step_type_versions enable row level security;
+alter table tenant_step_type_installs enable row level security;
+alter table tenant_secret_bindings enable row level security;
+alter table tenant_workflow_overlays enable row level security;
+alter table workflow_overlay_snapshots enable row level security;
+alter table workflow_overlay_layers enable row level security;
 
 create policy "Members read organisations" on organisations
   for select
@@ -225,3 +326,99 @@ create policy "Service role manages audit log" on audit_log
   for all
   using (auth.role() = 'service_role')
   with check (auth.role() = 'service_role');
+
+create policy "Service role manages json schemas" on json_schemas
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Admins read json schemas" on json_schemas
+  for select
+  using (auth.role() in ('service_role', 'authenticated'));
+
+create policy "Service role manages step types" on step_types
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Admins read step types" on step_types
+  for select
+  using (auth.role() in ('service_role', 'authenticated'));
+
+create policy "Service role manages step type versions" on step_type_versions
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Admins read step type versions" on step_type_versions
+  for select
+  using (auth.role() in ('service_role', 'authenticated'));
+
+create policy "Service role manages tenant installs" on tenant_step_type_installs
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Tenant members read installs" on tenant_step_type_installs
+  for select
+  using (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(org_id)
+  );
+
+create policy "Service role manages tenant secret bindings" on tenant_secret_bindings
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Tenant members manage secret bindings" on tenant_secret_bindings
+  for select
+  using (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(org_id)
+  );
+
+create policy "Service role manages tenant overlays" on tenant_workflow_overlays
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Tenant members manage overlays" on tenant_workflow_overlays
+  for select
+  using (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(org_id)
+  )
+  with check (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(org_id)
+  );
+
+create policy "Service role manages overlay snapshots" on workflow_overlay_snapshots
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Members read overlay snapshots" on workflow_overlay_snapshots
+  for select
+  using (
+    auth.role() = 'service_role'
+    or (run_id is not null and public.can_access_run(run_id))
+  );
+
+create policy "Service role manages overlay layers" on workflow_overlay_layers
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Members read overlay layers" on workflow_overlay_layers
+  for select
+  using (
+    auth.role() = 'service_role'
+    or exists (
+      select 1
+      from workflow_overlay_snapshots s
+      where s.id = snapshot_id
+        and public.can_access_run(s.run_id)
+    )
+  );

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -6,6 +6,7 @@
   "main": "src/engine.ts",
   "types": "src/engine.ts",
   "dependencies": {
+    "fast-json-patch": "^3.1.1",
     "js-yaml": "^4.1.0"
   },
   "exports": {

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -1,6 +1,112 @@
+import { applyPatch, type Operation } from "fast-json-patch";
 import { WorkflowDSL, StepDef } from "./types.js";
 
-export function materializeSteps(dsl: WorkflowDSL): StepDef[] {
-  // MVP: return steps as-is; branching handled later
-  return dsl.steps;
+export type OverlayPatch = {
+  operations: Operation[];
+  source?: string;
+};
+
+export interface MaterializeOptions {
+  overlays?: OverlayPatch[];
+}
+
+export interface MaterializeResult {
+  workflow: WorkflowDSL;
+  steps: StepDef[];
+  warnings: string[];
+}
+
+function cloneWorkflow(dsl: WorkflowDSL): WorkflowDSL {
+  return structuredClone(dsl);
+}
+
+function validateGraphIntegrity(workflow: WorkflowDSL): string[] {
+  const ids = new Set(workflow.steps.map((step) => step.id));
+  const issues: string[] = [];
+
+  for (const step of workflow.steps) {
+    for (const requirement of step.requires ?? []) {
+      if (!ids.has(requirement)) {
+        issues.push(`Step ${step.id} requires missing step ${requirement}`);
+      }
+    }
+  }
+
+  for (const edge of workflow.edges ?? []) {
+    if (!ids.has(edge.from)) {
+      issues.push(`Edge references missing step ${edge.from}`);
+    }
+    if (!ids.has(edge.to)) {
+      issues.push(`Edge references missing step ${edge.to}`);
+    }
+  }
+
+  return issues;
+}
+
+function validateSecretBindings(workflow: WorkflowDSL): string[] {
+  const issues: string[] = [];
+
+  for (const step of workflow.steps) {
+    const explicitSecrets = step.secrets && typeof step.secrets === "object" ? step.secrets : undefined;
+    const metadataSecrets =
+      step.metadata && typeof step.metadata === "object" && "secrets" in step.metadata
+        ? ((step.metadata as Record<string, unknown>).secrets as Record<string, { alias?: string; value?: unknown }> | undefined)
+        : undefined;
+    const secrets = (explicitSecrets ?? metadataSecrets ?? {}) as Record<string, { alias?: string; value?: unknown }>;
+
+    for (const [key, binding] of Object.entries(secrets)) {
+      if (!binding || typeof binding !== "object") {
+        issues.push(`Step ${step.id} secret ${key} must reference an alias object.`);
+        continue;
+      }
+
+      if ("value" in binding || (binding as Record<string, unknown>).value) {
+        issues.push(`Step ${step.id} secret ${key} must not embed a raw value.`);
+      }
+
+      if (typeof binding.alias !== "string" || binding.alias.trim().length === 0) {
+        issues.push(`Step ${step.id} secret ${key} must provide a non-empty alias.`);
+      }
+    }
+  }
+
+  return issues;
+}
+
+export function materializeWorkflow(dsl: WorkflowDSL, options: MaterializeOptions = {}): MaterializeResult {
+  const overlays = options.overlays ?? [];
+  let workflow = cloneWorkflow(dsl);
+
+  for (const overlay of overlays) {
+    if (!overlay.operations || overlay.operations.length === 0) {
+      continue;
+    }
+
+    const result = applyPatch(cloneWorkflow(workflow), overlay.operations, true, false);
+    if (!result.newDocument) {
+      throw new Error(`Failed to apply overlay patch${overlay.source ? ` from ${overlay.source}` : ""}`);
+    }
+    workflow = result.newDocument as WorkflowDSL;
+  }
+
+  const graphIssues = validateGraphIntegrity(workflow);
+  if (graphIssues.length > 0) {
+    throw new Error(graphIssues.join("\n"));
+  }
+
+  const secretIssues = validateSecretBindings(workflow);
+  if (secretIssues.length > 0) {
+    throw new Error(secretIssues.join("\n"));
+  }
+
+  return {
+    workflow,
+    steps: workflow.steps,
+    warnings: [],
+  };
+}
+
+export function materializeSteps(dsl: WorkflowDSL, overlays: OverlayPatch[] = []): StepDef[] {
+  return materializeWorkflow(dsl, { overlays }).steps;
 }

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -3,6 +3,13 @@ export type RuleRef = { id: string };
 export type StepExecution = {
   mode: "manual" | "temporal";
   workflow?: string;
+  taskQueue?: string;
+  config?: Record<string, unknown>;
+};
+
+export type StepSecretBinding = {
+  alias: string;
+  metadata?: Record<string, unknown>;
 };
 
 export type StepDef = {
@@ -12,5 +19,22 @@ export type StepDef = {
   requires?: string[];
   verify?: RuleRef[];
   execution?: StepExecution;
+  required?: boolean;
+  stepType?: string;
+  input?: Record<string, unknown>;
+  secrets?: Record<string, StepSecretBinding>;
+  metadata?: Record<string, unknown>;
 };
-export type WorkflowDSL = { id: string; version: string; questions?: any[]; branches?: any[]; steps: StepDef[] };
+
+export type WorkflowEdge = { from: string; to: string; condition?: string };
+
+export type WorkflowDSL = {
+  id: string;
+  version: string;
+  title?: string;
+  questions?: any[];
+  branches?: any[];
+  steps: StepDef[];
+  edges?: WorkflowEdge[];
+  metadata?: Record<string, unknown>;
+};

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -9,9 +9,30 @@ export const Membership = z.object({ userId: Id, orgId: Id, role: z.enum(["owner
 export const Engagement = z.object({ id: Id, engagerOrgId: Id, clientOrgId: Id, status: z.enum(["active", "ended"]) });
 
 export const WorkflowDef = z.object({ id: Id, key: z.string(), version: z.string(), title: z.string() });
-export const WorkflowRun = z.object({ id: Id, workflowDefId: Id, subjectOrgId: Id, engagerOrgId: Id.optional(), status: z.enum(["draft", "active", "done", "archived"]) });
+export const WorkflowRun = z.object({
+  id: Id,
+  workflowDefId: Id,
+  subjectOrgId: Id,
+  engagerOrgId: Id.optional(),
+  status: z.enum(["draft", "active", "done", "archived"]),
+  orchestrationProvider: z.string().optional(),
+  orchestrationWorkflowId: z.string().optional(),
+  mergedWorkflowSnapshot: z.record(z.any()).optional()
+});
 
-export const Step = z.object({ id: Id, runId: Id, key: z.string(), title: z.string(), status: z.enum(["todo", "in_progress", "waiting", "blocked", "done"]), dueDate: z.string().datetime().optional(), assigneeUserId: Id.optional() });
+export const Step = z.object({
+  id: Id,
+  runId: Id,
+  key: z.string(),
+  title: z.string(),
+  status: z.enum(["todo", "in_progress", "waiting", "blocked", "done"]),
+  orchestrationRunId: z.string().optional(),
+  executionMode: z.enum(["manual", "temporal"]).optional(),
+  dueDate: z.string().datetime().optional(),
+  assigneeUserId: Id.optional(),
+  stepTypeVersionId: Id.optional(),
+  permissions: z.array(z.string()).optional()
+});
 
 export type TOrg = z.infer<typeof Org>;
 

--- a/packages/types/src/supabase.ts
+++ b/packages/types/src/supabase.ts
@@ -160,7 +160,10 @@ export type Database = {
           subject_org_id: string;
           engager_org_id: string | null;
           status: "draft" | "active" | "done" | "archived";
+          orchestration_provider: string;
+          orchestration_workflow_id: string | null;
           created_by_user_id: string | null;
+          merged_workflow_snapshot: Json | null;
           created_at: string | null;
         };
         Insert: {
@@ -169,7 +172,10 @@ export type Database = {
           subject_org_id: string;
           engager_org_id?: string | null;
           status?: "draft" | "active" | "done" | "archived";
+          orchestration_provider?: string;
+          orchestration_workflow_id?: string | null;
           created_by_user_id?: string | null;
+          merged_workflow_snapshot?: Json | null;
           created_at?: string | null;
         };
         Update: {
@@ -178,7 +184,10 @@ export type Database = {
           subject_org_id?: string;
           engager_org_id?: string | null;
           status?: "draft" | "active" | "done" | "archived";
+          orchestration_provider?: string;
+          orchestration_workflow_id?: string | null;
           created_by_user_id?: string | null;
+          merged_workflow_snapshot?: Json | null;
           created_at?: string | null;
         };
         Relationships: [
@@ -219,8 +228,12 @@ export type Database = {
           key: string;
           title: string;
           status: "todo" | "in_progress" | "waiting" | "blocked" | "done";
+          orchestration_run_id: string | null;
+          execution_mode: "manual" | "temporal";
           due_date: string | null;
           assignee_user_id: string | null;
+          step_type_version_id: string | null;
+          permissions: string[] | null;
         };
         Insert: {
           id?: string;
@@ -228,8 +241,12 @@ export type Database = {
           key: string;
           title: string;
           status?: "todo" | "in_progress" | "waiting" | "blocked" | "done";
+          orchestration_run_id?: string | null;
+          execution_mode?: "manual" | "temporal";
           due_date?: string | null;
           assignee_user_id?: string | null;
+          step_type_version_id?: string | null;
+          permissions?: string[] | null;
         };
         Update: {
           id?: string;
@@ -237,8 +254,12 @@ export type Database = {
           key?: string;
           title?: string;
           status?: "todo" | "in_progress" | "waiting" | "blocked" | "done";
+          orchestration_run_id?: string | null;
+          execution_mode?: "manual" | "temporal";
           due_date?: string | null;
           assignee_user_id?: string | null;
+          step_type_version_id?: string | null;
+          permissions?: string[] | null;
         };
         Relationships: [
           {
@@ -253,6 +274,361 @@ export type Database = {
             columns: ["run_id"];
             isOneToOne: false;
             referencedRelation: "workflow_runs";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "steps_step_type_version_id_fkey";
+            columns: ["step_type_version_id"];
+            isOneToOne: false;
+            referencedRelation: "step_type_versions";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+      json_schemas: {
+        Row: {
+          id: string;
+          slug: string;
+          version: string;
+          description: string | null;
+          schema: Json;
+          created_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          slug: string;
+          version: string;
+          description?: string | null;
+          schema: Json;
+          created_at?: string | null;
+        };
+        Update: {
+          id?: string;
+          slug?: string;
+          version?: string;
+          description?: string | null;
+          schema?: Json;
+          created_at?: string | null;
+        };
+        Relationships: [];
+      };
+      step_types: {
+        Row: {
+          id: string;
+          slug: string;
+          title: string;
+          category: string | null;
+          summary: string | null;
+          latest_version: string | null;
+          created_by: string | null;
+          created_at: string | null;
+          updated_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          slug: string;
+          title: string;
+          category?: string | null;
+          summary?: string | null;
+          latest_version?: string | null;
+          created_by?: string | null;
+          created_at?: string | null;
+          updated_at?: string | null;
+        };
+        Update: {
+          id?: string;
+          slug?: string;
+          title?: string;
+          category?: string | null;
+          summary?: string | null;
+          latest_version?: string | null;
+          created_by?: string | null;
+          created_at?: string | null;
+          updated_at?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "step_types_created_by_fkey";
+            columns: ["created_by"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+      step_type_versions: {
+        Row: {
+          id: string;
+          step_type_id: string;
+          version: string;
+          definition: Json;
+          input_schema_id: string | null;
+          output_schema_id: string | null;
+          status: "draft" | "published" | "deprecated";
+          created_by: string | null;
+          created_at: string | null;
+          published_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          step_type_id: string;
+          version: string;
+          definition: Json;
+          input_schema_id?: string | null;
+          output_schema_id?: string | null;
+          status?: "draft" | "published" | "deprecated";
+          created_by?: string | null;
+          created_at?: string | null;
+          published_at?: string | null;
+        };
+        Update: {
+          id?: string;
+          step_type_id?: string;
+          version?: string;
+          definition?: Json;
+          input_schema_id?: string | null;
+          output_schema_id?: string | null;
+          status?: "draft" | "published" | "deprecated";
+          created_by?: string | null;
+          created_at?: string | null;
+          published_at?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "step_type_versions_created_by_fkey";
+            columns: ["created_by"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "step_type_versions_input_schema_id_fkey";
+            columns: ["input_schema_id"];
+            isOneToOne: false;
+            referencedRelation: "json_schemas";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "step_type_versions_output_schema_id_fkey";
+            columns: ["output_schema_id"];
+            isOneToOne: false;
+            referencedRelation: "json_schemas";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "step_type_versions_step_type_id_fkey";
+            columns: ["step_type_id"];
+            isOneToOne: false;
+            referencedRelation: "step_types";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+      tenant_step_type_installs: {
+        Row: {
+          id: string;
+          org_id: string;
+          step_type_version_id: string;
+          installed_at: string | null;
+          status: "enabled" | "disabled";
+        };
+        Insert: {
+          id?: string;
+          org_id: string;
+          step_type_version_id: string;
+          installed_at?: string | null;
+          status?: "enabled" | "disabled";
+        };
+        Update: {
+          id?: string;
+          org_id?: string;
+          step_type_version_id?: string;
+          installed_at?: string | null;
+          status?: "enabled" | "disabled";
+        };
+        Relationships: [
+          {
+            foreignKeyName: "tenant_step_type_installs_org_id_fkey";
+            columns: ["org_id"];
+            isOneToOne: false;
+            referencedRelation: "organisations";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "tenant_step_type_installs_step_type_version_id_fkey";
+            columns: ["step_type_version_id"];
+            isOneToOne: false;
+            referencedRelation: "step_type_versions";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+      tenant_secret_bindings: {
+        Row: {
+          id: string;
+          org_id: string;
+          alias: string;
+          description: string | null;
+          provider: string | null;
+          external_id: string;
+          created_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          org_id: string;
+          alias: string;
+          description?: string | null;
+          provider?: string | null;
+          external_id: string;
+          created_at?: string | null;
+        };
+        Update: {
+          id?: string;
+          org_id?: string;
+          alias?: string;
+          description?: string | null;
+          provider?: string | null;
+          external_id?: string;
+          created_at?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "tenant_secret_bindings_org_id_fkey";
+            columns: ["org_id"];
+            isOneToOne: false;
+            referencedRelation: "organisations";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+      tenant_workflow_overlays: {
+        Row: {
+          id: string;
+          org_id: string;
+          workflow_def_id: string;
+          title: string;
+          patch: Json;
+          status: "draft" | "published" | "archived";
+          created_by: string | null;
+          updated_at: string | null;
+          created_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          org_id: string;
+          workflow_def_id: string;
+          title: string;
+          patch: Json;
+          status?: "draft" | "published" | "archived";
+          created_by?: string | null;
+          updated_at?: string | null;
+          created_at?: string | null;
+        };
+        Update: {
+          id?: string;
+          org_id?: string;
+          workflow_def_id?: string;
+          title?: string;
+          patch?: Json;
+          status?: "draft" | "published" | "archived";
+          created_by?: string | null;
+          updated_at?: string | null;
+          created_at?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "tenant_workflow_overlays_created_by_fkey";
+            columns: ["created_by"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "tenant_workflow_overlays_org_id_fkey";
+            columns: ["org_id"];
+            isOneToOne: false;
+            referencedRelation: "organisations";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "tenant_workflow_overlays_workflow_def_id_fkey";
+            columns: ["workflow_def_id"];
+            isOneToOne: false;
+            referencedRelation: "workflow_defs";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+      workflow_overlay_snapshots: {
+        Row: {
+          id: string;
+          run_id: string;
+          tenant_overlay_id: string | null;
+          applied_overlays: Json;
+          merged_workflow: Json;
+          created_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          run_id: string;
+          tenant_overlay_id?: string | null;
+          applied_overlays?: Json;
+          merged_workflow: Json;
+          created_at?: string | null;
+        };
+        Update: {
+          id?: string;
+          run_id?: string;
+          tenant_overlay_id?: string | null;
+          applied_overlays?: Json;
+          merged_workflow?: Json;
+          created_at?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "workflow_overlay_snapshots_run_id_fkey";
+            columns: ["run_id"];
+            isOneToOne: false;
+            referencedRelation: "workflow_runs";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "workflow_overlay_snapshots_tenant_overlay_id_fkey";
+            columns: ["tenant_overlay_id"];
+            isOneToOne: false;
+            referencedRelation: "tenant_workflow_overlays";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+      workflow_overlay_layers: {
+        Row: {
+          id: string;
+          snapshot_id: string;
+          source: string;
+          patch: Json;
+          created_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          snapshot_id: string;
+          source: string;
+          patch: Json;
+          created_at?: string | null;
+        };
+        Update: {
+          id?: string;
+          snapshot_id?: string;
+          source?: string;
+          patch?: Json;
+          created_at?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "workflow_overlay_layers_snapshot_id_fkey";
+            columns: ["snapshot_id"];
+            isOneToOne: false;
+            referencedRelation: "workflow_overlay_snapshots";
             referencedColumns: ["id"];
           }
         ];

--- a/packages/workflow-packs/src/types.ts
+++ b/packages/workflow-packs/src/types.ts
@@ -37,6 +37,7 @@ export interface ImpactMap {
 
 export interface MergeResult {
   workflow: WorkflowDefinition;
+  snapshot: WorkflowDefinition;
   impactMap: ImpactMap;
   warnings: string[];
 }


### PR DESCRIPTION
## Summary
- add guardrails in the tenant overlay builder to validate secret aliases, auto-correct invalid selections, and surface inline errors
- localize the new validation messages and wire them into the overlay builder page labels
- block persistence when overlays fail to merge so invalid snapshots are not queued

## Testing
- pnpm --filter @airnub/portal lint *(fails: next not found because workspace dependencies are not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb0aa5184832491e52be2d4237d21