### PR TITLE
feat: add external job workflow and secure webhook ingress

### DIFF
--- a/apps/portal/src/app/api/hooks/[tenantId]/[channel]/route.ts
+++ b/apps/portal/src/app/api/hooks/[tenantId]/[channel]/route.ts
@@ -1,0 +1,136 @@
+import { NextResponse } from "next/server";
+import {
+  signalWorkflow,
+  resolveSecretAlias,
+  SecretAliasResolutionError
+} from "@airnub/orchestrator-temporal";
+
+import {
+  assertUniqueNonce,
+  NonceReplayError,
+  SignatureVerificationError,
+  verifySignature
+} from "../../_lib/security";
+import { resolveChannelConfig } from "../../_lib/channels";
+
+function safeJsonParse(payload: string): unknown {
+  if (!payload) {
+    return null;
+  }
+  try {
+    return JSON.parse(payload);
+  } catch (error) {
+    throw new Error("Invalid JSON payload");
+  }
+}
+
+function pickHeaders(headers: Headers): Record<string, string> {
+  const allowList = ["content-type", "user-agent", "x-fc-signature", "x-fc-nonce"];
+  const collected: Record<string, string> = {};
+  for (const key of allowList) {
+    const value = headers.get(key);
+    if (value) {
+      collected[key] = value;
+    }
+  }
+  return collected;
+}
+
+export async function POST(
+  request: Request,
+  context: { params: { tenantId: string; channel: string } }
+) {
+  const { tenantId, channel } = context.params;
+  const config = resolveChannelConfig(tenantId, channel);
+
+  if (!config) {
+    return NextResponse.json(
+      { ok: false, error: "Unknown tenant/channel" },
+      { status: 404 }
+    );
+  }
+
+  const rawBody = await request.text();
+  let body: unknown;
+  try {
+    body = safeJsonParse(rawBody);
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: (error as Error).message }, { status: 400 });
+  }
+
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ ok: false, error: "Payload must be a JSON object" }, { status: 400 });
+  }
+
+  const workflowId = (body as Record<string, unknown>).workflowId;
+  if (typeof workflowId !== "string" || workflowId.length === 0) {
+    return NextResponse.json({ ok: false, error: "workflowId is required" }, { status: 400 });
+  }
+
+  const signalName = config.signal ?? "receivedCallback";
+
+  let verification: { timestamp: number; version: string } | undefined;
+  const nonceHeader = request.headers.get("x-fc-nonce") ?? "";
+  const signatureHeader = request.headers.get("x-fc-signature") ?? "";
+
+  if (config.signatureSecretAlias) {
+    if (!nonceHeader) {
+      return NextResponse.json({ ok: false, error: "Missing nonce header" }, { status: 400 });
+    }
+    if (!signatureHeader) {
+      return NextResponse.json({ ok: false, error: "Missing signature header" }, { status: 400 });
+    }
+
+    try {
+      const secret = resolveSecretAlias(tenantId, config.signatureSecretAlias);
+      const verified = verifySignature({
+        secret,
+        signatureHeader,
+        nonce: nonceHeader,
+        payload: rawBody,
+        toleranceSeconds: config.toleranceSeconds
+      });
+      verification = { timestamp: verified.timestamp, version: verified.version };
+      assertUniqueNonce(`${tenantId}:${channel}`, nonceHeader, config.nonceTtlSeconds);
+    } catch (error) {
+      if (error instanceof SecretAliasResolutionError) {
+        return NextResponse.json(
+          { ok: false, error: "Unable to resolve secret alias" },
+          { status: 503 }
+        );
+      }
+      if (error instanceof SignatureVerificationError) {
+        return NextResponse.json({ ok: false, error: error.message }, { status: 401 });
+      }
+      if (error instanceof NonceReplayError) {
+        return NextResponse.json({ ok: false, error: error.message }, { status: 409 });
+      }
+      return NextResponse.json({ ok: false, error: "Unable to verify request" }, { status: 500 });
+    }
+  }
+
+  try {
+    const signalResult = await signalWorkflow({
+      workflowId,
+      signal: signalName,
+      payload: {
+        tenantId,
+        channel,
+        nonce: nonceHeader || null,
+        verification,
+        headers: pickHeaders(request.headers),
+        payload: body,
+        receivedAt: new Date().toISOString()
+      }
+    });
+
+    return NextResponse.json({
+      ok: true,
+      status: signalResult.status,
+      result: signalResult.result
+    });
+  } catch (error) {
+    console.error("[hooks] Failed to signal workflow", error);
+    return NextResponse.json({ ok: false, error: "Failed to dispatch signal" }, { status: 502 });
+  }
+}

--- a/apps/portal/src/app/api/hooks/_lib/channels.ts
+++ b/apps/portal/src/app/api/hooks/_lib/channels.ts
@@ -1,0 +1,25 @@
+export interface ChannelConfig {
+  signal?: string;
+  signatureSecretAlias?: string;
+  toleranceSeconds?: number;
+  nonceTtlSeconds?: number;
+}
+
+const CHANNEL_REGISTRY: Record<string, Record<string, ChannelConfig>> = {
+  "tenant-x": {
+    "sysY-enrich": {
+      signal: "receivedCallback",
+      signatureSecretAlias: "secrets.webhooks.sysY",
+      toleranceSeconds: 5 * 60,
+      nonceTtlSeconds: 10 * 60
+    }
+  }
+};
+
+export function resolveChannelConfig(tenantId: string, channel: string): ChannelConfig | undefined {
+  const tenantConfig = CHANNEL_REGISTRY[tenantId];
+  if (!tenantConfig) {
+    return undefined;
+  }
+  return tenantConfig[channel];
+}

--- a/apps/portal/src/app/api/hooks/_lib/security.ts
+++ b/apps/portal/src/app/api/hooks/_lib/security.ts
@@ -1,0 +1,122 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+export interface SignatureVerificationInput {
+  secret: string;
+  signatureHeader: string;
+  nonce: string;
+  payload: string;
+  toleranceSeconds?: number;
+}
+
+export interface VerifiedSignature {
+  timestamp: number;
+  signature: string;
+  version: string;
+}
+
+const DEFAULT_TOLERANCE = 5 * 60; // five minutes
+
+export class SignatureVerificationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SignatureVerificationError";
+  }
+}
+
+export class NonceReplayError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NonceReplayError";
+  }
+}
+
+function getReplayCache(): Map<string, number> {
+  const globalScope = globalThis as typeof globalThis & {
+    __fcReplayCache?: Map<string, number>;
+  };
+
+  if (!globalScope.__fcReplayCache) {
+    globalScope.__fcReplayCache = new Map();
+  }
+
+  return globalScope.__fcReplayCache;
+}
+
+export function assertUniqueNonce(key: string, nonce: string, ttlSeconds = DEFAULT_TOLERANCE) {
+  if (!nonce) {
+    throw new NonceReplayError("Missing nonce");
+  }
+
+  const cache = getReplayCache();
+  const now = Date.now();
+  const expiresAt = now + ttlSeconds * 1000;
+
+  for (const [entryKey, expiry] of cache.entries()) {
+    if (expiry <= now) {
+      cache.delete(entryKey);
+    }
+  }
+
+  const compositeKey = `${key}:${nonce}`;
+  if (cache.has(compositeKey)) {
+    throw new NonceReplayError("Nonce has already been used");
+  }
+
+  cache.set(compositeKey, expiresAt);
+}
+
+function parseSignatureHeader(header: string): VerifiedSignature {
+  const parts = header.split(",");
+  const values = Object.fromEntries(
+    parts
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .map((part) => {
+        const [key, value] = part.split("=");
+        return [key, value];
+      })
+  );
+
+  const timestamp = Number(values.t);
+  if (!Number.isFinite(timestamp)) {
+    throw new SignatureVerificationError("Missing timestamp in signature header");
+  }
+
+  const signature = values.v1 ?? values.sig;
+  if (!signature) {
+    throw new SignatureVerificationError("Missing signature digest");
+  }
+
+  const version = values.v ?? "v1";
+
+  return { timestamp, signature, version };
+}
+
+export function verifySignature(input: SignatureVerificationInput): VerifiedSignature {
+  const { secret, signatureHeader, nonce, payload, toleranceSeconds = DEFAULT_TOLERANCE } = input;
+
+  if (!signatureHeader) {
+    throw new SignatureVerificationError("Missing signature header");
+  }
+
+  const parsed = parseSignatureHeader(signatureHeader);
+  const ageSeconds = Math.abs(Date.now() / 1000 - parsed.timestamp);
+  if (ageSeconds > toleranceSeconds) {
+    throw new SignatureVerificationError("Signature timestamp outside tolerance");
+  }
+
+  const canonical = `${parsed.timestamp}.${nonce}.${payload}`;
+  const expected = createHmac("sha256", secret).update(canonical).digest("hex");
+  const provided = parsed.signature;
+
+  try {
+    const matches = timingSafeEqual(Buffer.from(expected, "hex"), Buffer.from(provided, "hex"));
+    if (!matches) {
+      throw new SignatureVerificationError("Signature verification failed");
+    }
+  } catch (error) {
+    throw new SignatureVerificationError("Signature verification failed");
+  }
+
+  return parsed;
+}

--- a/examples/packs/tenant-x/messages/en-IE.json
+++ b/examples/packs/tenant-x/messages/en-IE.json
@@ -2,4 +2,6 @@
   "tenantx-ml-screening.title": "Machine learning screening (Tenant X)",
   "tenantx-ml-screening.description": "Automated screening that checks directors against Tenant X risk heuristics.",
   "tenantx-policy-attest.title": "Board policy attestation (Tenant X)",
-  "tenantx-policy-attest.description": "Collect signed confirmation that the board adopted Tenant X security policy."}
+  "tenantx-policy-attest.description": "Collect signed confirmation that the board adopted Tenant X security policy.",
+  "tenantx-sysy-enrichment.title": "System Y enrichment job",
+  "tenantx-sysy-enrichment.description": "Launch and monitor the System Y enrichment workflow via secure webhook ingress and polling fallback."}

--- a/examples/packs/tenant-x/overlay.patch.json
+++ b/examples/packs/tenant-x/overlay.patch.json
@@ -47,6 +47,63 @@
     }
   },
   {
+    "op": "add",
+    "path": "/steps/-",
+    "value": {
+      "id": "tenantx-sysy-enrichment",
+      "kind": "action",
+      "title_i18n": {
+        "en-IE": "System Y enrichment job"
+      },
+      "description_i18n": {
+        "en-IE": "Launches the System Y data enrichment job and waits for the secure callback or polling confirmation."
+      },
+      "stepType": "external-job-with-callback@1.0.0",
+      "execution": {
+        "mode": "temporal",
+        "workflow": "externalJobWorkflow",
+        "config": {
+          "workflow": "externalJobWorkflow",
+          "externalRefPath": "body.ticketId",
+          "egress": {
+            "method": "POST",
+            "urlAlias": "secrets.sysY.baseUrl",
+            "tokenAlias": "secrets.sysY.apiToken",
+            "path": "/v1/enrich",
+            "headers": {
+              "X-SystemY-Tenant": "tenant-x"
+            },
+            "signingSecretAlias": "secrets.sysY.egress"
+          },
+          "ingress": {
+            "timeoutSeconds": 900,
+            "escalateReason": "ingress_timeout"
+          },
+          "polling": {
+            "enabled": true,
+            "intervalSeconds": 30,
+            "maxAttempts": 40,
+            "statusPath": "/v1/jobs/{{ticketId}}",
+            "successWhen": {
+              "path": "body.status",
+              "equals": "complete"
+            },
+            "failureWhen": {
+              "path": "body.status",
+              "in": ["failed", "cancelled"]
+            }
+          },
+          "notesOnSuccess": "System Y enrichment completed",
+          "notesOnFailure": "System Y enrichment requires manual review"
+        }
+      },
+      "requires": ["tenantx-ml-screening"],
+      "verify": [
+        { "rule": "sysy_enrichment_complete" }
+      ]
+    }
+  },
+  {
     "op": "replace",
     "path": "/steps/8/requires",
     "value": ["tenantx-policy-attest"]

--- a/packages/orchestrator-temporal/package.json
+++ b/packages/orchestrator-temporal/package.json
@@ -6,7 +6,7 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {
-    "test": "tsx --test src/**/*.test.ts"
+    "test": "tsx --test src/**/*.test.ts src/*.test.ts"
   },
   "exports": {
     ".": "./src/index.ts",
@@ -18,7 +18,8 @@
     "@airnub/doc-templates": "workspace:*",
     "@temporalio/client": "^1.11.0",
     "@temporalio/workflow": "^1.11.0",
-    "@temporalio/worker": "^1.11.0"
+    "@temporalio/worker": "^1.11.0",
+    "undici": "^5.28.4"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/packages/orchestrator-temporal/src/activities/externalJob.ts
+++ b/packages/orchestrator-temporal/src/activities/externalJob.ts
@@ -1,0 +1,123 @@
+import { performSignedHttpRequest, type HttpRequestConfig } from "./http.js";
+import { persistStepProgress, recordAuditEvent, type StepActivityContext } from "./util.js";
+
+export interface ExternalJobStartInput extends StepActivityContext {
+  tenantId: string;
+  request: HttpRequestConfig;
+}
+
+export interface ExternalJobStartResult {
+  http: Awaited<ReturnType<typeof performSignedHttpRequest>>;
+}
+
+export interface ExternalJobPollInput extends StepActivityContext {
+  tenantId: string;
+  request: HttpRequestConfig;
+  success?: { path: string; equals?: unknown; in?: unknown[] };
+  failure?: { path: string; equals?: unknown; in?: unknown[] };
+  attempt: number;
+}
+
+export type ExternalJobPollStatus = "running" | "completed" | "failed";
+
+export interface ExternalJobPollResult {
+  status: ExternalJobPollStatus;
+  response: Awaited<ReturnType<typeof performSignedHttpRequest>>;
+}
+
+export interface PersistExternalResultInput<T = unknown> extends StepActivityContext {
+  status: "in_progress" | "waiting" | "done" | "blocked" | "todo";
+  output?: T;
+  notes?: string;
+}
+
+export interface EscalationInput extends StepActivityContext {
+  reason: string;
+  metadata?: Record<string, unknown>;
+}
+
+function getByPath(payload: unknown, path?: string): unknown {
+  if (!path || !payload || typeof payload !== "object") {
+    return undefined;
+  }
+
+  const segments = path.split(".").filter(Boolean);
+  let current: unknown = payload;
+  for (const segment of segments) {
+    if (!current || typeof current !== "object") {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+function matchesCondition(target: unknown, condition?: { equals?: unknown; in?: unknown[] }): boolean {
+  if (!condition) {
+    return false;
+  }
+  if (Object.prototype.hasOwnProperty.call(condition, "equals")) {
+    return target === condition.equals;
+  }
+  if (Array.isArray(condition.in)) {
+    return condition.in.some((item) => item === target);
+  }
+  return false;
+}
+
+export async function startExternalJob(input: ExternalJobStartInput): Promise<ExternalJobStartResult> {
+  const http = await performSignedHttpRequest({
+    tenantId: input.tenantId,
+    context: input,
+    request: input.request
+  });
+
+  await persistStepProgress({
+    orgId: input.orgId,
+    runId: input.runId,
+    stepKey: input.stepKey,
+    status: "waiting",
+    output: { http },
+    notes: "External job initiated; awaiting callback"
+  });
+
+  return { http };
+}
+
+export async function pollExternalJob(input: ExternalJobPollInput): Promise<ExternalJobPollResult> {
+  const response = await performSignedHttpRequest({
+    tenantId: input.tenantId,
+    context: input,
+    request: input.request,
+    idempotencyKey: `${input.runId}:${input.stepKey}:poll:${input.attempt}`
+  });
+
+  const successTarget = getByPath(response.body, input.success?.path);
+  if (matchesCondition(successTarget, input.success)) {
+    return { status: "completed", response };
+  }
+
+  const failureTarget = getByPath(response.body, input.failure?.path);
+  if (matchesCondition(failureTarget, input.failure)) {
+    return { status: "failed", response };
+  }
+
+  return { status: "running", response };
+}
+
+export async function persistExternalResult<T>(input: PersistExternalResultInput<T>) {
+  return await persistStepProgress(input);
+}
+
+export async function escalateExternalJob(input: EscalationInput) {
+  await recordAuditEvent({
+    orgId: input.orgId,
+    runId: input.runId,
+    stepKey: input.stepKey,
+    action: "external_job_escalation",
+    metadata: {
+      reason: input.reason,
+      ...input.metadata
+    }
+  });
+}

--- a/packages/orchestrator-temporal/src/activities/http.ts
+++ b/packages/orchestrator-temporal/src/activities/http.ts
@@ -1,0 +1,147 @@
+import { createHash, createHmac } from "node:crypto";
+import { fetch, Headers, Response } from "undici";
+import { resolveSecretAlias } from "../secrets.js";
+import type { StepActivityContext } from "./util.js";
+
+export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+export interface HttpRequestConfig {
+  method: HttpMethod;
+  urlAlias: string;
+  path?: string;
+  tokenAlias?: string;
+  headers?: Record<string, string>;
+  signingSecretAlias?: string;
+  query?: Record<string, string | number | boolean | undefined>;
+  body?: unknown;
+}
+
+export interface HttpExecutionContext {
+  tenantId: string;
+  context: StepActivityContext;
+  request: HttpRequestConfig;
+  idempotencyKey?: string;
+}
+
+export interface HttpExecutionResult {
+  ok: boolean;
+  status: number;
+  requestHash: string;
+  responseHash?: string;
+  headers: Record<string, string>;
+  bodyText?: string;
+  body?: unknown;
+}
+
+function buildUrl(baseUrl: string, path?: string, query?: HttpRequestConfig["query"]): string {
+  const url = new URL(path ?? "", baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`);
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      if (value === undefined || value === null) {
+        continue;
+      }
+      url.searchParams.set(key, String(value));
+    }
+  }
+  return url.toString();
+}
+
+function hashPayload(payload?: string): string {
+  const hash = createHash("sha256");
+  hash.update(payload ?? "");
+  return hash.digest("hex");
+}
+
+async function parseBody(response: Response): Promise<{ bodyText?: string; body?: unknown }> {
+  const contentType = response.headers.get("content-type") ?? "";
+  const text = await response.text();
+  if (!text) {
+    return {};
+  }
+
+  if (contentType.includes("application/json")) {
+    try {
+      return { bodyText: text, body: JSON.parse(text) };
+    } catch (error) {
+      console.warn("[http-activity] Unable to parse JSON response", error);
+      return { bodyText: text };
+    }
+  }
+
+  return { bodyText: text };
+}
+
+export async function performSignedHttpRequest(options: HttpExecutionContext): Promise<HttpExecutionResult> {
+  const { tenantId, context, request, idempotencyKey } = options;
+  const baseUrl = resolveSecretAlias(tenantId, request.urlAlias);
+  const token = request.tokenAlias ? resolveSecretAlias(tenantId, request.tokenAlias) : undefined;
+  const signingSecret = request.signingSecretAlias
+    ? resolveSecretAlias(tenantId, request.signingSecretAlias)
+    : undefined;
+
+  const url = buildUrl(baseUrl, request.path, request.query);
+  const headers = new Headers();
+  headers.set("User-Agent", "fresh-comply-temporal/1.0");
+  headers.set("X-FC-Idempotency-Key", idempotencyKey ?? `${context.runId}:${context.stepKey}`);
+  headers.set("X-FC-Run-Id", context.runId);
+  headers.set("X-FC-Step-Key", context.stepKey);
+
+  for (const [key, value] of Object.entries(request.headers ?? {})) {
+    headers.set(key, value);
+  }
+
+  let bodyString: string | undefined;
+  if (request.body !== undefined && request.body !== null) {
+    if (!headers.has("Content-Type")) {
+      headers.set("Content-Type", "application/json");
+    }
+    bodyString = typeof request.body === "string" ? request.body : JSON.stringify(request.body);
+  }
+
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+
+  if (signingSecret && bodyString) {
+    const signature = createHmac("sha256", signingSecret).update(bodyString).digest("hex");
+    headers.set("X-FC-Signature", signature);
+  }
+
+  const response = await fetch(url, {
+    method: request.method,
+    headers,
+    body: bodyString
+  });
+
+  const responseHeaders: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    responseHeaders[key.toLowerCase()] = value;
+  });
+
+  const { bodyText, body } = await parseBody(response);
+
+  const result: HttpExecutionResult = {
+    ok: response.ok,
+    status: response.status,
+    requestHash: hashPayload(bodyString),
+    responseHash: hashPayload(bodyText),
+    headers: responseHeaders,
+    bodyText,
+    body
+  };
+
+  if (!response.ok) {
+    const error = new Error(
+      `HTTP request failed with status ${response.status}: ${bodyText ?? response.statusText}`
+    );
+    (error as Error & { metadata?: unknown }).metadata = {
+      status: response.status,
+      url,
+      headers: responseHeaders,
+      responseHash: result.responseHash
+    };
+    throw error;
+  }
+
+  return result;
+}

--- a/packages/orchestrator-temporal/src/index.ts
+++ b/packages/orchestrator-temporal/src/index.ts
@@ -7,7 +7,8 @@ const WORKFLOW_REGISTRY = {
   croNameCheckWorkflow: workflows.croNameCheckWorkflow,
   a1PackBuildWorkflow: workflows.a1PackBuildWorkflow,
   tr2SubmissionWorkflow: workflows.tr2SubmissionWorkflow,
-  etaxClearanceWorkflow: workflows.etaxClearanceWorkflow
+  etaxClearanceWorkflow: workflows.etaxClearanceWorkflow,
+  externalJobWorkflow: workflows.externalJobWorkflow
 } as const;
 
 export type SupportedWorkflow = keyof typeof WORKFLOW_REGISTRY;
@@ -102,3 +103,10 @@ export async function queryWorkflowStatus(workflowId: string) {
     await client.connection.close();
   }
 }
+
+export {
+  resolveSecretAlias,
+  generateNonce,
+  getSecretCacheDebugSnapshot,
+  SecretAliasResolutionError
+} from "./secrets.js";

--- a/packages/orchestrator-temporal/src/secrets.test.ts
+++ b/packages/orchestrator-temporal/src/secrets.test.ts
@@ -1,0 +1,21 @@
+import { strict as assert } from "node:assert";
+import test from "node:test";
+
+import {
+  clearSecretCache,
+  resolveSecretAlias,
+  SecretAliasResolutionError
+} from "./secrets.js";
+
+test("resolveSecretAlias reads tenant scoped variables", () => {
+  clearSecretCache();
+  process.env.FC_SECRET_TENANT_X__API_TOKEN = "super-secret";
+  const value = resolveSecretAlias("tenant-x", "api.token");
+  assert.equal(value, "super-secret");
+});
+
+test("resolveSecretAlias throws when alias missing", () => {
+  clearSecretCache();
+  delete process.env.FC_SECRET_TENANT_X__MISSING;
+  assert.throws(() => resolveSecretAlias("tenant-x", "missing"), SecretAliasResolutionError);
+});

--- a/packages/orchestrator-temporal/src/secrets.ts
+++ b/packages/orchestrator-temporal/src/secrets.ts
@@ -1,0 +1,70 @@
+import { randomUUID } from "node:crypto";
+
+const SECRET_CACHE = new Map<string, string>();
+
+function formatCacheKey(tenantId: string, alias: string): string {
+  return `${tenantId}::${alias}`;
+}
+
+function sanitizeIdentifier(value: string): string {
+  return value
+    .trim()
+    .replace(/[^a-zA-Z0-9]/g, "_")
+    .replace(/_{2,}/g, "_")
+    .toUpperCase();
+}
+
+function candidateEnvKeys(tenantId: string, alias: string): string[] {
+  const tenantKey = sanitizeIdentifier(tenantId);
+  const aliasKey = sanitizeIdentifier(alias);
+  return [
+    `FC_SECRET_${tenantKey}__${aliasKey}`,
+    `FC_SECRET__${aliasKey}`,
+    `SECRET_${tenantKey}__${aliasKey}`,
+    `SECRET__${aliasKey}`
+  ];
+}
+
+export class SecretAliasResolutionError extends Error {
+  constructor(alias: string, tenantId: string) {
+    super(`Unable to resolve secret alias "${alias}" for tenant "${tenantId}".`);
+    this.name = "SecretAliasResolutionError";
+  }
+}
+
+export function resolveSecretAlias(tenantId: string, alias: string): string {
+  if (!tenantId || !alias) {
+    throw new SecretAliasResolutionError(alias, tenantId);
+  }
+
+  const cacheKey = formatCacheKey(tenantId, alias);
+  if (SECRET_CACHE.has(cacheKey)) {
+    return SECRET_CACHE.get(cacheKey)!;
+  }
+
+  const envKeys = candidateEnvKeys(tenantId, alias);
+  for (const key of envKeys) {
+    const value = process.env[key];
+    if (typeof value === "string" && value.length > 0) {
+      SECRET_CACHE.set(cacheKey, value);
+      return value;
+    }
+  }
+
+  throw new SecretAliasResolutionError(alias, tenantId);
+}
+
+export function clearSecretCache() {
+  SECRET_CACHE.clear();
+}
+
+export function getSecretCacheDebugSnapshot(): Array<{ key: string; length: number }> {
+  return Array.from(SECRET_CACHE.entries()).map(([key, value]) => ({
+    key,
+    length: value.length
+  }));
+}
+
+export function generateNonce(): string {
+  return randomUUID();
+}

--- a/packages/orchestrator-temporal/src/worker.ts
+++ b/packages/orchestrator-temporal/src/worker.ts
@@ -3,6 +3,7 @@ import * as croActivities from "./activities/cro.js";
 import * as revenueActivities from "./activities/revenue.js";
 import * as fileActivities from "./activities/files.js";
 import * as utilActivities from "./activities/util.js";
+import * as externalJobActivities from "./activities/externalJob.js";
 import { createTemporalConnection, getTaskQueue, getTemporalNamespace } from "./client.js";
 
 async function runWorker() {
@@ -15,7 +16,8 @@ async function runWorker() {
       ...croActivities,
       ...revenueActivities,
       ...fileActivities,
-      ...utilActivities
+      ...utilActivities,
+      ...externalJobActivities
     },
     taskQueue: getTaskQueue()
   });

--- a/packages/orchestrator-temporal/src/workflows/externalJob.workflow.ts
+++ b/packages/orchestrator-temporal/src/workflows/externalJob.workflow.ts
@@ -1,0 +1,301 @@
+import { condition, proxyActivities, setHandler, sleep } from "@temporalio/workflow";
+import type * as externalJobActivities from "../activities/externalJob.js";
+import {
+  getResultQuery,
+  getStatusQuery,
+  receivedCallbackSignal,
+  type ExternalJobCallbackPayload,
+  type StepWorkflowInput,
+  type StepWorkflowStatus
+} from "./shared.js";
+import type { HttpRequestConfig, HttpMethod } from "../activities/http.js";
+
+interface ExternalJobIngressConfig {
+  timeoutSeconds?: number;
+  escalateReason?: string;
+}
+
+interface ExternalJobPollingCondition {
+  path: string;
+  equals?: unknown;
+  in?: unknown[];
+}
+
+interface ExternalJobPollingConfig {
+  enabled?: boolean;
+  intervalSeconds?: number;
+  maxAttempts?: number;
+  statusPath: string;
+  method?: HttpMethod;
+  headers?: Record<string, string>;
+  urlAlias?: string;
+  tokenAlias?: string;
+  signingSecretAlias?: string;
+  successWhen?: ExternalJobPollingCondition;
+  failureWhen?: ExternalJobPollingCondition;
+}
+
+export interface ExternalJobWorkflowPayload {
+  tenantId: string;
+  egress: HttpRequestConfig;
+  payload?: unknown;
+  externalRefPath?: string;
+  ingress?: ExternalJobIngressConfig;
+  polling?: ExternalJobPollingConfig;
+  notesOnSuccess?: string;
+  notesOnFailure?: string;
+  metadata?: Record<string, unknown>;
+}
+
+const externalActivities = proxyActivities<typeof externalJobActivities>({
+  startToCloseTimeout: "2 minutes",
+  retry: {
+    maximumAttempts: 3
+  }
+});
+
+function getByPath(payload: unknown, path?: string): unknown {
+  if (!path || !payload || typeof payload !== "object") {
+    return undefined;
+  }
+  const segments = path.split(".").filter(Boolean);
+  let current: unknown = payload;
+  for (const segment of segments) {
+    if (!current || typeof current !== "object") {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+function applyTemplate(template: string, context: Record<string, string | undefined>): string {
+  return template.replace(/{{\s*([^}]+)\s*}}/g, (_, token: string) => {
+    const key = token.trim();
+    const value = context[key];
+    return value ?? "";
+  });
+}
+
+function normalizeCallback(
+  payload: ExternalJobCallbackPayload | undefined,
+  externalRef?: string,
+  metadata?: Record<string, unknown>
+): ExternalJobCallbackPayload {
+  const status = payload?.status ?? "pending";
+  return {
+    ...payload,
+    status,
+    externalRef: payload?.externalRef ?? externalRef,
+    receivedAt: payload?.receivedAt ?? new Date().toISOString(),
+    metadata: {
+      ...(payload?.metadata ?? {}),
+      ...(metadata ?? {})
+    }
+  };
+}
+
+function isSuccessStatus(status?: string) {
+  return status === "success" || status === "completed";
+}
+
+export async function externalJobWorkflow(
+  input: StepWorkflowInput<ExternalJobWorkflowPayload>
+): Promise<unknown> {
+  let status: StepWorkflowStatus = "pending";
+  let result: unknown;
+
+  setHandler(getStatusQuery, () => status);
+  setHandler(getResultQuery, () => result);
+
+  let callbackPayload: ExternalJobCallbackPayload | undefined;
+  let externalRef: string | undefined;
+
+  setHandler(receivedCallbackSignal, (payload) => {
+    callbackPayload = normalizeCallback(payload, externalRef, { via: "signal" });
+  });
+
+  status = "running";
+
+  const requestConfig: HttpRequestConfig = {
+    ...input.payload.egress,
+    body: input.payload.payload
+  };
+
+  const startResult = await externalActivities.startExternalJob({
+    tenantId: input.payload.tenantId,
+    orgId: input.orgId,
+    runId: input.runId,
+    stepKey: input.stepKey,
+    request: requestConfig
+  });
+
+  externalRef = getByPath(startResult.http.body, input.payload.externalRefPath) as string | undefined;
+
+  status = "awaiting_signal";
+
+  const waitForCallback = condition(() => callbackPayload !== undefined);
+
+  const pollingConfig = input.payload.polling;
+  const ingressConfig = input.payload.ingress;
+
+  const watchers: Array<Promise<void>> = [];
+
+  if (ingressConfig?.timeoutSeconds && ingressConfig.timeoutSeconds > 0) {
+    watchers.push(
+      (async () => {
+        await sleep(ingressConfig.timeoutSeconds * 1000);
+        if (callbackPayload) {
+          return;
+        }
+        await externalActivities.escalateExternalJob({
+          orgId: input.orgId,
+          runId: input.runId,
+          stepKey: input.stepKey,
+          reason: ingressConfig.escalateReason ?? "ingress_timeout",
+          metadata: {
+            timeoutSeconds: ingressConfig.timeoutSeconds,
+            externalRef,
+            runId: input.runId,
+            stepKey: input.stepKey
+          }
+        });
+        if (!pollingConfig?.enabled) {
+          callbackPayload = normalizeCallback(
+            {
+              status: "failed",
+              error: { message: "Timed out waiting for callback" }
+            },
+            externalRef,
+            { via: "timeout" }
+          );
+        }
+      })()
+    );
+  }
+
+  if (pollingConfig?.enabled && pollingConfig.statusPath) {
+    const interval = Math.max(5, pollingConfig.intervalSeconds ?? 30);
+    const maxAttempts = Math.max(1, pollingConfig.maxAttempts ?? 20);
+    const pollRequest: HttpRequestConfig = {
+      method: pollingConfig.method ?? "GET",
+      urlAlias: pollingConfig.urlAlias ?? input.payload.egress.urlAlias,
+      tokenAlias: pollingConfig.tokenAlias ?? input.payload.egress.tokenAlias,
+      signingSecretAlias:
+        pollingConfig.signingSecretAlias ?? input.payload.egress.signingSecretAlias,
+      headers: pollingConfig.headers,
+      path: applyTemplate(pollingConfig.statusPath, {
+        ticketId: externalRef,
+        externalRef
+      })
+    };
+
+    watchers.push(
+      (async () => {
+        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+          await sleep(interval * 1000);
+          if (callbackPayload) {
+            return;
+          }
+          try {
+            const pollResult = await externalActivities.pollExternalJob({
+              tenantId: input.payload.tenantId,
+              orgId: input.orgId,
+              runId: input.runId,
+              stepKey: input.stepKey,
+              request: pollRequest,
+              success: pollingConfig.successWhen,
+              failure: pollingConfig.failureWhen,
+              attempt
+            });
+
+            if (pollResult.status === "completed") {
+              callbackPayload = normalizeCallback(
+                {
+                  status: "success",
+                  output: pollResult.response.body
+                },
+                externalRef,
+                { via: "polling", attempt }
+              );
+              return;
+            }
+
+            if (pollResult.status === "failed") {
+              callbackPayload = normalizeCallback(
+                {
+                  status: "failed",
+                  output: pollResult.response.body,
+                  error: { message: "Polling reported failure" }
+                },
+                externalRef,
+                { via: "polling", attempt }
+              );
+              return;
+            }
+          } catch (error) {
+            await externalActivities.escalateExternalJob({
+              orgId: input.orgId,
+              runId: input.runId,
+              stepKey: input.stepKey,
+              reason: "polling_error",
+              metadata: {
+                attempt,
+                error: (error as Error).message,
+                externalRef
+              }
+            });
+          }
+        }
+
+        if (!callbackPayload) {
+          await externalActivities.escalateExternalJob({
+            orgId: input.orgId,
+            runId: input.runId,
+            stepKey: input.stepKey,
+            reason: "polling_exhausted",
+            metadata: {
+              attempts: maxAttempts,
+              intervalSeconds: interval,
+              externalRef
+            }
+          });
+          callbackPayload = normalizeCallback(
+            {
+              status: "failed",
+              error: { message: "Polling attempts exhausted" }
+            },
+            externalRef,
+            { via: "polling", exhausted: true }
+          );
+        }
+      })()
+    );
+  }
+
+  await waitForCallback;
+  await Promise.allSettled(watchers);
+
+  const persisted = await externalActivities.persistExternalResult({
+    orgId: input.orgId,
+    runId: input.runId,
+    stepKey: input.stepKey,
+    status: isSuccessStatus(callbackPayload?.status) ? "done" : "blocked",
+    output: {
+      start: startResult.http,
+      callback: callbackPayload
+    },
+    notes: isSuccessStatus(callbackPayload?.status)
+      ? input.payload.notesOnSuccess ?? "External job completed"
+      : input.payload.notesOnFailure ?? "External job failed or timed out"
+  });
+
+  status = isSuccessStatus(callbackPayload?.status) ? "completed" : "failed";
+  result = {
+    start: startResult,
+    final: callbackPayload,
+    persisted
+  };
+
+  return result;
+}

--- a/packages/orchestrator-temporal/src/workflows/index.ts
+++ b/packages/orchestrator-temporal/src/workflows/index.ts
@@ -2,3 +2,4 @@ export { croNameCheckWorkflow } from "./croNameCheck.workflow.js";
 export { a1PackBuildWorkflow } from "./a1PackBuild.workflow.js";
 export { tr2SubmissionWorkflow } from "./tr2Submission.workflow.js";
 export { etaxClearanceWorkflow } from "./etaxClearance.workflow.js";
+export { externalJobWorkflow } from "./externalJob.workflow.js";

--- a/packages/orchestrator-temporal/src/workflows/shared.ts
+++ b/packages/orchestrator-temporal/src/workflows/shared.ts
@@ -18,6 +18,17 @@ export const confirmManualFilingSignal = defineSignal<[{ receiptUrl?: string; no
   "confirmManualFiling"
 );
 
+export type ExternalJobCallbackPayload = {
+  status?: "success" | "error" | "pending" | "completed" | "failed";
+  output?: unknown;
+  error?: { message: string; code?: string; details?: unknown };
+  externalRef?: string;
+  receivedAt?: string;
+  metadata?: Record<string, unknown>;
+};
+
+export const receivedCallbackSignal = defineSignal<[ExternalJobCallbackPayload]>("receivedCallback");
+
 export const getStatusQuery = defineQuery<StepWorkflowStatus>("getStatus");
 
 export const getResultQuery = defineQuery<unknown>("getResult");


### PR DESCRIPTION
## Summary
- add Temporal external job workflow with polling, escalation, and secure HTTP activities
- expose secret alias helpers and signed HTTP client utilities for overlays and worker registration
- add multi-tenant webhook ingress route with HMAC + nonce enforcement and document/demo the overlay wiring

## Testing
- pnpm --filter @airnub/orchestrator-temporal test

------
https://chatgpt.com/codex/tasks/task_e_68dfbb638ef08324a556f0f99ec567fe