### PR TITLE
Renumber white-label architecture ADR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,8 @@ docs/adr/0001-temporal-orchestration.md
 ADR-0002: Stripe Billing Scaffold (White-Label Tenants)
 docs/adr/0002-billing-stripe.md
 
-ADR-0002: White-Label Multi-Tenant Architecture
-docs/adr/0002-white-label-multi-tenant-architecture.md
+ADR-0003: White-Label Multi-Tenant Architecture
+docs/adr/0003-white-label-multi-tenant-architecture.md
 
 Superseded / Archive
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,8 +7,8 @@
 - **White-Label Architecture (v2025-10-03)** — `specs/fresh_comply_white_label_multi_tenant_architecture_v_2025_10_03.md`
 - **Secure Bidirectional Integration Architecture (v2025-10-03)** — `specs/integration-architecture-bidirectional.md`
 - **ADR-0001: Temporal Orchestration** — `../adr/0001-temporal-orchestration.md`
-- **ADR-0002: White-Label Multi-Tenant Architecture** — `../adr/0002-white-label-multi-tenant-architecture.md`
-- **ADR-0003: Stripe Billing Scaffold** — `../adr/0002-billing-stripe.md`
+- **ADR-0003: White-Label Multi-Tenant Architecture** — `../adr/0003-white-label-multi-tenant-architecture.md`
+- **ADR-0002: Stripe Billing Scaffold** — `../adr/0002-billing-stripe.md`
 
 ## Superseded / Archive
 - **Live Workflow — Irish Non-Profit Setup (Product Spec) (v2025-10-02)** — `../archive/2025-10-02-live-workflow-nonprofit-ie.md`

--- a/docs/adr/0003-white-label-multi-tenant-architecture.md
+++ b/docs/adr/0003-white-label-multi-tenant-architecture.md
@@ -1,4 +1,4 @@
-# ADR-0002: White-Label Multi-Tenant Architecture
+# ADR-0003: White-Label Multi-Tenant Architecture
 
 - **Status:** Accepted
 - **Date:** 2025-10-03


### PR DESCRIPTION
## Summary
- rename the white-label architecture ADR to ADR-0003 and update its heading to match the new identifier
- update AGENTS.md and the docs index to point to the renamed ADR and correct the Stripe billing entry

## Testing
- npx markdown-link-check docs/README.md
- npx markdown-link-check AGENTS.md
- npx markdown-link-check docs/adr/0003-white-label-multi-tenant-architecture.md

------
https://chatgpt.com/codex/tasks/task_e_68dfc5a3aa088324a573990cf2cdc967