### PR TITLE
Add accessibility and Temporal linting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,33 @@ on:
       - main
   pull_request:
 
-jobs:
-  quality:
-    runs-on: ubuntu-latest
+permissions:
+  contents: read
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PNPM_VERSION: 10.0.0
+  NODE_VERSION: 20
+  NEXT_TELEMETRY_DISABLED: '1'
+
+jobs:
+  node-quality:
+    name: ${{ matrix.display }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        task: [lint, typecheck, test]
+        include:
+          - task: lint
+            display: Lint
+          - task: typecheck
+            display: Typecheck
+          - task: test
+            display: Unit tests
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -17,25 +40,122 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.0.0
+          version: ${{ env.PNPM_VERSION }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'pnpm'
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run lint
-        run: pnpm lint
+      - name: Run ${{ matrix.display }}
+        run: pnpm ${{ matrix.task }}
 
-      - name: Run typecheck
-        run: pnpm typecheck
+  accessibility:
+    name: Accessibility
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
 
-      - name: Run tests
-        run: pnpm test
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build portal
+        run: pnpm --filter @airnub/portal build
+
+      - name: Start portal server
+        run: |
+          pnpm --filter @airnub/portal start -- --hostname 0.0.0.0 --port 3000 &
+          echo $! > portal.pid
+
+      - name: Wait for portal
+        run: pnpm dlx wait-on http://127.0.0.1:3000
+
+      - name: Run Cypress axe suite
+        run: pnpm --filter @airnub/portal test:a11y
+
+      - name: Run pa11y regression suite
+        run: pnpm --filter @airnub/portal test:pa11y
+
+      - name: Stop portal server
+        if: always()
+        run: |
+          if [ -f portal.pid ]; then
+            kill $(cat portal.pid)
+          fi
+
+  temporal-worker:
+    name: Temporal worker lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint Temporal worker bundle
+        run: pnpm --filter @airnub/orchestrator-temporal lint
+
+  database:
+    name: Database policies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Dry-run database migrations
+        run: pnpm --filter @airnub/db run migrate --dry-run
+
+      - name: Check Supabase RLS policies
+        run: node packages/db/check-rls.mjs
+
+  docs-links:
+    name: Documentation links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
 
       - name: Check Markdown links
         uses: lycheeverse/lychee-action@v2
@@ -46,9 +166,3 @@ jobs:
             --base .
             ./AGENTS.md
             './docs/**/*.md'
-
-      - name: Dry-run database migrations
-        run: pnpm --filter @airnub/db run migrate --dry-run
-
-      - name: Check Supabase RLS policies
-        run: node packages/db/check-rls.mjs

--- a/README.md
+++ b/README.md
@@ -43,15 +43,33 @@ The command prints a summary table to the console and writes both JSON and Markd
 
 ## CI expectations
 
-All pull requests run an automated workflow that checks linting, type safety, tests, documentation links, and database policies. Run the same commands locally before opening a PR:
+All pull requests run an automated workflow with required status checks for linting, type safety, unit tests, accessibility regressions (Cypress axe + pa11y), Temporal worker linting, database guards, and Markdown link hygiene. Configure the `main` branch protection rule in GitHub to require the following checks before merging:
+
+- `Lint`
+- `Typecheck`
+- `Unit tests`
+- `Accessibility`
+- `Temporal worker lint`
+- `Database policies`
+- `Documentation links`
+
+Run the same commands locally before opening a PR:
 
 ```bash
 pnpm lint
 pnpm typecheck
 pnpm test
+pnpm --filter @airnub/portal build
+pnpm --filter @airnub/portal start -- --hostname 0.0.0.0 --port 3000 &
+PORTAL_PID=$!
+pnpm --filter @airnub/portal test:a11y
+pnpm --filter @airnub/portal test:pa11y
+kill $PORTAL_PID
+pnpm --filter @airnub/orchestrator-temporal lint
 pnpm --filter @airnub/db run migrate --dry-run
 node packages/db/check-rls.mjs
 pnpm dlx lychee --no-progress --markdown --base . ./AGENTS.md './docs/**/*.md'
 ```
 
-Installing [`lychee`](https://github.com/lycheeverse/lychee) via `pnpm dlx` keeps the Markdown link checker aligned with CI.
+> [!NOTE]
+> Installing [`lychee`](https://github.com/lycheeverse/lychee) via `pnpm dlx` keeps the Markdown link checker aligned with CI.

--- a/packages/orchestrator-temporal/package.json
+++ b/packages/orchestrator-temporal/package.json
@@ -6,6 +6,7 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {
+    "lint": "tsc --noEmit",
     "test": "tsx --test src/**/*.test.ts src/*.test.ts"
   },
   "exports": {


### PR DESCRIPTION
## Summary
- restructure the CI workflow to run lint, typecheck, and test in a pnpm-cached matrix
- add dedicated jobs for accessibility (Cypress axe + pa11y), Temporal worker linting, database checks, and Markdown link validation
- document the required status checks and local commands to mirror CI coverage

## Testing
- not run (workflow updates only)


------
https://chatgpt.com/codex/tasks/task_e_68dfc9f8ba988324a91df515c33fd880