### PR TITLE
feat(admin): wire step type admin flows to supabase

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -6,6 +6,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "vitest run",
     "test:a11y": "echo 'Run axe/Pa11y via root scripts'"
   },
   "dependencies": {
@@ -29,6 +30,11 @@
     "@types/node": "^20.14.10",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@testing-library/jest-dom": "^6.4.6",
+    "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.5.2",
+    "happy-dom": "^15.8.3",
+    "vitest": "^2.1.3",
     "eslint": "^8.57.0",
     "eslint-config-next": "15.0.0",
     "typescript": "^5.5.4",

--- a/apps/admin/src/app/[locale]/step-types/__tests__/step-type-actions.test.tsx
+++ b/apps/admin/src/app/[locale]/step-types/__tests__/step-type-actions.test.tsx
@@ -1,0 +1,149 @@
+import React from "react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { StepTypeActionsClient } from "../step-type-actions.client";
+import type {
+  StepTypeRegistryEntry,
+  StepTypeVersionLedgerEntry,
+  TenantSecretBinding,
+  TenantStepTypeInstall,
+} from "../types";
+
+const registry: StepTypeRegistryEntry[] = [
+  {
+    id: "st-1",
+    slug: "temporal.webhook",
+    title: "Temporal Webhook",
+    category: "automation",
+    latest_version: "1.0.0",
+    summary: "",
+    published_versions: 1,
+  },
+];
+
+const versions: StepTypeVersionLedgerEntry[] = [
+  {
+    id: "stv-1",
+    step_type_slug: "temporal.webhook",
+    version: "1.0.0",
+    status: "draft",
+    published_at: null,
+    schema_slug: "schemas/example@1",
+  },
+];
+
+const installs: TenantStepTypeInstall[] = [];
+const bindings: TenantSecretBinding[] = [];
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+describe("StepTypeActionsClient", () => {
+  beforeEach(() => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ message: "ok", auditId: "audit-123" }),
+    } as Response);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("submits publish flow to admin API", async () => {
+    render(
+      <StepTypeActionsClient
+        registry={registry}
+        versions={versions}
+        tenantInstalls={installs}
+        secretBindings={bindings}
+      />
+    );
+
+    const stepSelect = screen.getAllByTestId("publish-step-type-select")[0];
+    await userEvent.selectOptions(stepSelect, "st-1");
+
+    const publishForm = await screen.findByTestId("publish-form");
+    const versionSelect = within(publishForm).getByTestId("publish-version-select");
+    await userEvent.selectOptions(versionSelect, "stv-1");
+
+    const reason = await screen.findByLabelText(/Reason code/i, { selector: "textarea#publish-reason" });
+    await userEvent.type(reason, "publishing to production");
+
+    const submit = await screen.findByRole("button", { name: /Publish version/i });
+    await userEvent.click(submit);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/admin/step-types/st-1/publish",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({ "content-type": "application/json" }),
+        })
+      );
+    });
+
+    const payload = JSON.parse((global.fetch as unknown as vi.Mock).mock.calls[0][1].body as string);
+    expect(payload).toMatchObject({
+      reason: "publishing to production",
+      version: "stv-1",
+    });
+
+    const publishStatuses = await screen.findAllByRole("status");
+    const publishStatus = publishStatuses[publishStatuses.length - 1];
+    expect(publishStatus).toHaveTextContent("ok");
+    expect(publishStatus).toHaveTextContent("audit-123");
+  });
+
+  it("submits tenant install flow to admin API", async () => {
+    (global.fetch as unknown as vi.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ message: "install complete", auditId: "audit-install" }),
+    } as Response);
+
+    render(
+      <StepTypeActionsClient
+        registry={registry}
+        versions={versions}
+        tenantInstalls={installs}
+        secretBindings={bindings}
+      />
+    );
+
+    const stepSelect = screen.getAllByTestId("install-step-type-select")[0];
+    await userEvent.selectOptions(stepSelect, "st-1");
+
+    const orgField = await screen.findByLabelText(/Tenant organisation slug/i);
+    await userEvent.type(orgField, "tenant-one");
+
+    const installForm = await screen.findByTestId("install-form");
+    const versionSelect = within(installForm).getByTestId("install-version-select");
+    await userEvent.selectOptions(versionSelect, "stv-1");
+
+    const reason = await screen.findByLabelText(/Reason code/i, { selector: "textarea#install-reason" });
+    await userEvent.type(reason, "enable for beta");
+
+    const submit = await screen.findByRole("button", { name: /Enable tenant/i });
+    await userEvent.click(submit);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/admin/step-types/st-1/tenants",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+
+    const payload = JSON.parse((global.fetch as unknown as vi.Mock).mock.calls[0][1].body as string);
+    expect(payload).toMatchObject({
+      reason: "enable for beta",
+      install: { org_slug: "tenant-one", version_id: "stv-1", follow_latest: false },
+    });
+
+    const installStatuses = await screen.findAllByRole("status");
+    const installStatus = installStatuses[installStatuses.length - 1];
+    expect(installStatus).toHaveTextContent("install complete");
+    expect(installStatus).toHaveTextContent("audit-install");
+  });
+});

--- a/apps/admin/src/app/[locale]/step-types/loaders.ts
+++ b/apps/admin/src/app/[locale]/step-types/loaders.ts
@@ -1,0 +1,82 @@
+import "server-only";
+
+import { cache } from "react";
+import { getSupabaseServiceRoleClient } from "@/lib/auth/supabase-service-role";
+
+import type {
+  StepTypeRegistryEntry,
+  StepTypeVersionLedgerEntry,
+  TenantStepTypeInstall,
+  TenantSecretBinding,
+  WorkflowOverlaySnapshot,
+} from "./types";
+
+interface RpcError {
+  message: string;
+  details?: string | null;
+  hint?: string | null;
+}
+
+async function callRpc<T>(procedure: string, params: Record<string, unknown> = {}): Promise<T> {
+  const client = getSupabaseServiceRoleClient();
+  const { data, error } = await client.rpc<T>(procedure, params);
+
+  if (error) {
+    const rpcError: RpcError = {
+      message: error.message,
+      details: "details" in error ? (error as RpcError).details : undefined,
+      hint: "hint" in error ? (error as RpcError).hint : undefined,
+    };
+
+    throw new Error(
+      `[admin:rpc] ${procedure} failed: ${rpcError.message}${rpcError.details ? ` — ${rpcError.details}` : ""}`
+    );
+  }
+
+  return (data ?? []) as T;
+}
+
+export const loadStepTypeRegistry = cache(async (): Promise<StepTypeRegistryEntry[]> => {
+  try {
+    return await callRpc<StepTypeRegistryEntry[]>("admin_list_step_types");
+  } catch (error) {
+    console.error("Failed to load step type registry", error);
+    return [];
+  }
+});
+
+export const loadStepTypeVersions = cache(async (): Promise<StepTypeVersionLedgerEntry[]> => {
+  try {
+    return await callRpc<StepTypeVersionLedgerEntry[]>("admin_list_step_type_versions");
+  } catch (error) {
+    console.error("Failed to load step type versions", error);
+    return [];
+  }
+});
+
+export const loadTenantInstalls = cache(async (): Promise<TenantStepTypeInstall[]> => {
+  try {
+    return await callRpc<TenantStepTypeInstall[]>("admin_list_tenant_step_type_installs");
+  } catch (error) {
+    console.error("Failed to load tenant installs", error);
+    return [];
+  }
+});
+
+export const loadSecretBindings = cache(async (): Promise<TenantSecretBinding[]> => {
+  try {
+    return await callRpc<TenantSecretBinding[]>("admin_list_tenant_secret_bindings");
+  } catch (error) {
+    console.error("Failed to load secret bindings", error);
+    return [];
+  }
+});
+
+export const loadOverlaySnapshots = cache(async (): Promise<WorkflowOverlaySnapshot[]> => {
+  try {
+    return await callRpc<WorkflowOverlaySnapshot[]>("admin_list_workflow_overlay_snapshots");
+  } catch (error) {
+    console.error("Failed to load workflow overlays", error);
+    return [];
+  }
+});

--- a/apps/admin/src/app/[locale]/step-types/step-type-actions.client.tsx
+++ b/apps/admin/src/app/[locale]/step-types/step-type-actions.client.tsx
@@ -1,0 +1,814 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import type {
+  StepTypeRegistryEntry,
+  StepTypeVersionLedgerEntry,
+  TenantSecretBinding,
+  TenantStepTypeInstall,
+} from "./types";
+import type { StepTypeActionsProps } from "./step-type-actions";
+import { ApiResultCallout } from "@/components/ApiResultCallout";
+
+interface MutationState {
+  submitting: boolean;
+  result: { message: string; auditId?: string | null; warnings?: string[] } | null;
+  error: { message: string; details?: string | null; validationErrors?: string[] | null } | null;
+}
+
+interface AdminMutationInit {
+  path: string;
+  method?: string;
+}
+
+function useAdminMutation({ path, method = "POST" }: AdminMutationInit) {
+  const router = useRouter();
+  const [state, setState] = useState<MutationState>({ submitting: false, result: null, error: null });
+
+  async function execute(payload: Record<string, unknown>) {
+    setState({ submitting: true, result: null, error: null });
+    try {
+      const response = await fetch(path, {
+        method,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const data = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+      if (!response.ok) {
+        setState({
+          submitting: false,
+          result: null,
+          error: {
+            message: (data.error as string) ?? "Request failed",
+            details: (data.details as string | undefined) ?? null,
+            validationErrors: (data.validationErrors as string[] | undefined) ?? null,
+          },
+        });
+        return null;
+      }
+
+      const result = {
+        message: (data.message as string) ?? "Mutation completed",
+        auditId: (data.auditId as string | undefined) ?? (data.audit_id as string | undefined) ?? null,
+        warnings: (data.warnings as string[] | undefined) ?? undefined,
+      };
+
+      setState({ submitting: false, result, error: null });
+      router.refresh();
+      return data;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Request failed";
+      setState({ submitting: false, result: null, error: { message } });
+      return null;
+    }
+  }
+
+  return { ...state, execute };
+}
+
+function StepTypeOption({ stepType }: { stepType: StepTypeRegistryEntry }) {
+  const label = `${stepType.title} (${stepType.slug})`;
+  return <option value={stepType.id}>{label}</option>;
+}
+
+const providers = [
+  { value: "hashicorp", label: "HashiCorp Vault" },
+  { value: "aws-sm", label: "AWS Secrets Manager" },
+  { value: "supabase-kv", label: "Supabase Vault" },
+  { value: "env", label: "Environment Variable" },
+];
+
+function resolveStepTypeById(registry: StepTypeRegistryEntry[], id: string | undefined) {
+  return registry.find((item) => item.id === id);
+}
+
+function resolveVersionForStepType(
+  versions: StepTypeVersionLedgerEntry[],
+  registry: StepTypeRegistryEntry[],
+  stepTypeId?: string
+) {
+  const stepType = stepTypeId ? resolveStepTypeById(registry, stepTypeId) : undefined;
+  if (!stepType) {
+    return versions.filter((version) => version.status !== "archived");
+  }
+
+  return versions.filter((version) => version.step_type_slug === stepType.slug);
+}
+
+export function StepTypeActionsClient({ registry, versions, tenantInstalls, secretBindings }: StepTypeActionsProps) {
+  const createMutation = useAdminMutation({ path: "/api/admin/step-types" });
+  const [createForm, setCreateForm] = useState({
+    slug: "",
+    title: "",
+    category: "automation",
+    summary: "",
+    executionMode: "manual",
+    version: "1.0.0",
+    inputSchemaSlug: "",
+    reason: "",
+  });
+
+  const [editStepTypeId, setEditStepTypeId] = useState<string | undefined>();
+  const editMutation = useAdminMutation({
+    path: editStepTypeId ? `/api/admin/step-types/${editStepTypeId}` : "/api/admin/step-types",
+    method: editStepTypeId ? "PATCH" : "POST",
+  });
+  const [editForm, setEditForm] = useState({
+    title: "",
+    summary: "",
+    executionMode: "manual",
+    inputSchemaSlug: "",
+    reason: "",
+  });
+
+  const [publishStepTypeId, setPublishStepTypeId] = useState<string | undefined>();
+  const publishMutation = useAdminMutation({
+    path: publishStepTypeId ? `/api/admin/step-types/${publishStepTypeId}/publish` : "/api/admin/step-types",
+  });
+  const [publishForm, setPublishForm] = useState({
+    version: "",
+    changelog: "",
+    reason: "",
+  });
+
+  const [installStepTypeId, setInstallStepTypeId] = useState<string | undefined>();
+  const installMutation = useAdminMutation({
+    path: installStepTypeId ? `/api/admin/step-types/${installStepTypeId}/tenants` : "/api/admin/step-types",
+  });
+  const [installForm, setInstallForm] = useState({
+    orgSlug: "",
+    versionId: "",
+    followLatest: false,
+    reason: "",
+  });
+
+  const [bindingStepTypeId, setBindingStepTypeId] = useState<string | undefined>();
+  const bindingMutation = useAdminMutation({
+    path: bindingStepTypeId ? `/api/admin/step-types/${bindingStepTypeId}/secret-bindings` : "/api/admin/step-types",
+  });
+  const [bindingForm, setBindingForm] = useState({
+    orgSlug: "",
+    alias: "",
+    provider: providers[0]?.value ?? "hashicorp",
+    externalId: "",
+    reason: "",
+  });
+
+  const selectedEditStepType = useMemo(() => resolveStepTypeById(registry, editStepTypeId), [registry, editStepTypeId]);
+  const selectedPublishStepType = useMemo(
+    () => resolveStepTypeById(registry, publishStepTypeId),
+    [registry, publishStepTypeId]
+  );
+  const selectedInstallStepType = useMemo(
+    () => resolveStepTypeById(registry, installStepTypeId),
+    [registry, installStepTypeId]
+  );
+  const selectedBindingStepType = useMemo(
+    () => resolveStepTypeById(registry, bindingStepTypeId),
+    [registry, bindingStepTypeId]
+  );
+
+  function handleEditSelection(stepTypeId: string) {
+    setEditStepTypeId(stepTypeId);
+    const next = resolveStepTypeById(registry, stepTypeId);
+    if (next) {
+      setEditForm({
+        title: next.title,
+        summary: next.summary ?? "",
+        executionMode: "manual",
+        inputSchemaSlug: "",
+        reason: "",
+      });
+    }
+  }
+
+  async function submitCreate(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    await createMutation.execute({
+      reason: createForm.reason,
+      stepType: {
+        slug: createForm.slug,
+        title: createForm.title,
+        category: createForm.category,
+        summary: createForm.summary,
+        execution_mode: createForm.executionMode,
+        version: createForm.version,
+        input_schema_slug: createForm.inputSchemaSlug,
+      },
+    });
+  }
+
+  async function submitEdit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!editStepTypeId) {
+      return;
+    }
+    await editMutation.execute({
+      reason: editForm.reason,
+      patch: {
+        title: editForm.title,
+        summary: editForm.summary,
+        execution_mode: editForm.executionMode,
+        input_schema_slug: editForm.inputSchemaSlug,
+      },
+    });
+  }
+
+  async function submitPublish(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!publishStepTypeId) {
+      return;
+    }
+    await publishMutation.execute({
+      reason: publishForm.reason,
+      version: publishForm.version,
+      changelog: publishForm.changelog,
+    });
+  }
+
+  async function submitInstall(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!installStepTypeId) {
+      return;
+    }
+    await installMutation.execute({
+      reason: installForm.reason,
+      install: {
+        org_slug: installForm.orgSlug,
+        version_id: installForm.versionId,
+        follow_latest: installForm.followLatest,
+      },
+    });
+  }
+
+  async function submitBinding(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!bindingStepTypeId) {
+      return;
+    }
+    await bindingMutation.execute({
+      reason: bindingForm.reason,
+      binding: {
+        org_slug: bindingForm.orgSlug,
+        alias: bindingForm.alias,
+        provider: bindingForm.provider,
+        external_id: bindingForm.externalId,
+      },
+    });
+  }
+
+  const versionOptions = useMemo(() => {
+    return versions.map((item) => ({
+      id: item.id,
+      label: `${item.step_type_slug}@${item.version} (${item.status})`,
+    }));
+  }, [versions]);
+
+  const installVersionOptions = useMemo(() => {
+    return resolveVersionForStepType(versions, registry, installStepTypeId).map((item) => ({
+      id: item.id,
+      label: `${item.step_type_slug}@${item.version} (${item.status})`,
+    }));
+  }, [versions, registry, installStepTypeId]);
+
+  const installTenantCount = useMemo(
+    () => new Set(tenantInstalls.map((install) => install.org_slug)).size,
+    [tenantInstalls]
+  );
+  const bindingTenantCount = useMemo(
+    () => new Set(secretBindings.map((binding) => binding.tenant_name)).size,
+    [secretBindings]
+  );
+
+  return (
+    <div className="grid gap-6 md:grid-cols-2">
+      <section className="space-y-4">
+        <div className="space-y-4 rounded-lg border border-gray-200 p-4">
+          <header className="space-y-1">
+            <h3 className="text-base font-semibold text-gray-900">Create step type</h3>
+            <p className="text-sm text-gray-600">Submit a new step type draft with an initial version.</p>
+          </header>
+          <form className="space-y-3" onSubmit={submitCreate}>
+            <div className="grid gap-2">
+              <label className="text-sm font-medium text-gray-700" htmlFor="create-slug">
+                Slug
+              </label>
+              <input
+                id="create-slug"
+                value={createForm.slug}
+                onChange={(event) => setCreateForm((prev) => ({ ...prev, slug: event.target.value }))}
+                required
+                className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <div className="grid gap-2">
+              <label className="text-sm font-medium text-gray-700" htmlFor="create-title">
+                Title
+              </label>
+              <input
+                id="create-title"
+                value={createForm.title}
+                onChange={(event) => setCreateForm((prev) => ({ ...prev, title: event.target.value }))}
+                required
+                className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <div className="grid gap-2">
+              <label className="text-sm font-medium text-gray-700" htmlFor="create-category">
+                Category
+              </label>
+              <input
+                id="create-category"
+                value={createForm.category}
+                onChange={(event) => setCreateForm((prev) => ({ ...prev, category: event.target.value }))}
+                required
+                className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <div className="grid gap-2">
+              <label className="text-sm font-medium text-gray-700" htmlFor="create-summary">
+                Summary
+              </label>
+              <textarea
+                id="create-summary"
+                value={createForm.summary}
+                onChange={(event) => setCreateForm((prev) => ({ ...prev, summary: event.target.value }))}
+                rows={3}
+                className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <div className="grid gap-2">
+              <label className="text-sm font-medium text-gray-700" htmlFor="create-execution-mode">
+                Execution mode
+              </label>
+              <select
+                id="create-execution-mode"
+                value={createForm.executionMode}
+                onChange={(event) => setCreateForm((prev) => ({ ...prev, executionMode: event.target.value }))}
+                className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              >
+                <option value="manual">Manual</option>
+                <option value="temporal">Temporal</option>
+                <option value="external:webhook">External — Webhook</option>
+                <option value="external:websocket">External — WebSocket</option>
+              </select>
+            </div>
+            <div className="grid gap-2">
+              <label className="text-sm font-medium text-gray-700" htmlFor="create-version">
+                Initial version
+              </label>
+              <input
+                id="create-version"
+                value={createForm.version}
+                onChange={(event) => setCreateForm((prev) => ({ ...prev, version: event.target.value }))}
+                required
+                pattern="^\\d+\\.\\d+\\.\\d+$"
+                className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <div className="grid gap-2">
+              <label className="text-sm font-medium text-gray-700" htmlFor="create-input-schema">
+                Input schema slug
+              </label>
+              <input
+                id="create-input-schema"
+                value={createForm.inputSchemaSlug}
+                onChange={(event) => setCreateForm((prev) => ({ ...prev, inputSchemaSlug: event.target.value }))}
+                className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="schemas/example@1"
+              />
+            </div>
+            <div className="grid gap-2">
+              <label className="text-sm font-medium text-gray-700" htmlFor="create-reason">
+                Reason code
+              </label>
+              <textarea
+                id="create-reason"
+                value={createForm.reason}
+                onChange={(event) => setCreateForm((prev) => ({ ...prev, reason: event.target.value }))}
+                required
+                rows={2}
+                className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={createMutation.submitting}
+              className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
+            >
+              {createMutation.submitting ? "Creating…" : "Create step type"}
+            </button>
+          </form>
+          <ApiResultCallout result={createMutation.result} error={createMutation.error} />
+        </div>
+
+        <div className="space-y-4 rounded-lg border border-gray-200 p-4">
+          <header className="space-y-1">
+            <h3 className="text-base font-semibold text-gray-900">Edit step type</h3>
+            <p className="text-sm text-gray-600">Update metadata and schemas for an existing step type.</p>
+          </header>
+          <div className="grid gap-2">
+            <label className="text-sm font-medium text-gray-700" htmlFor="edit-step-type">
+              Step type
+            </label>
+            <select
+              id="edit-step-type"
+              value={editStepTypeId ?? ""}
+              onChange={(event) => handleEditSelection(event.target.value)}
+              className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="" disabled>
+                Select a step type
+              </option>
+              {registry.map((stepType) => (
+                <StepTypeOption key={stepType.id} stepType={stepType} />
+              ))}
+            </select>
+          </div>
+          {selectedEditStepType ? (
+            <form className="space-y-3" onSubmit={submitEdit}>
+              <div className="grid gap-2">
+                <label className="text-sm font-medium text-gray-700" htmlFor="edit-title">
+                  Title
+                </label>
+                <input
+                  id="edit-title"
+                  value={editForm.title}
+                  onChange={(event) => setEditForm((prev) => ({ ...prev, title: event.target.value }))}
+                  required
+                  className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+              <div className="grid gap-2">
+                <label className="text-sm font-medium text-gray-700" htmlFor="edit-summary">
+                  Summary
+                </label>
+                <textarea
+                  id="edit-summary"
+                  value={editForm.summary}
+                  onChange={(event) => setEditForm((prev) => ({ ...prev, summary: event.target.value }))}
+                  rows={3}
+                  className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+              <div className="grid gap-2">
+                <label className="text-sm font-medium text-gray-700" htmlFor="edit-execution-mode">
+                  Execution mode
+                </label>
+                <select
+                  id="edit-execution-mode"
+                  value={editForm.executionMode}
+                  onChange={(event) => setEditForm((prev) => ({ ...prev, executionMode: event.target.value }))}
+                  className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                  <option value="manual">Manual</option>
+                  <option value="temporal">Temporal</option>
+                  <option value="external:webhook">External — Webhook</option>
+                  <option value="external:websocket">External — WebSocket</option>
+                </select>
+              </div>
+              <div className="grid gap-2">
+                <label className="text-sm font-medium text-gray-700" htmlFor="edit-input-schema">
+                  Input schema slug
+                </label>
+                <input
+                  id="edit-input-schema"
+                  value={editForm.inputSchemaSlug}
+                  onChange={(event) => setEditForm((prev) => ({ ...prev, inputSchemaSlug: event.target.value }))}
+                  className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+              <div className="grid gap-2">
+                <label className="text-sm font-medium text-gray-700" htmlFor="edit-reason">
+                  Reason code
+                </label>
+                <textarea
+                  id="edit-reason"
+                  value={editForm.reason}
+                  onChange={(event) => setEditForm((prev) => ({ ...prev, reason: event.target.value }))}
+                  required
+                  rows={2}
+                  className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+              <button
+                type="submit"
+                disabled={editMutation.submitting}
+                className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
+              >
+                {editMutation.submitting ? "Saving…" : "Save changes"}
+              </button>
+            </form>
+          ) : (
+            <p className="text-sm text-gray-500">Select a step type to edit.</p>
+          )}
+          <ApiResultCallout result={editMutation.result} error={editMutation.error} />
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <div className="space-y-4 rounded-lg border border-gray-200 p-4">
+          <header className="space-y-1">
+            <h3 className="text-base font-semibold text-gray-900">Publish version</h3>
+            <p className="text-sm text-gray-600">Publish a draft version to tenants and append an audit entry.</p>
+          </header>
+          <div className="grid gap-2">
+            <label className="text-sm font-medium text-gray-700" htmlFor="publish-step-type">
+              Step type
+            </label>
+            <select
+              id="publish-step-type"
+              value={publishStepTypeId ?? ""}
+              onChange={(event) => setPublishStepTypeId(event.target.value)}
+              data-testid="publish-step-type-select"
+              className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="" disabled>
+                Select a step type
+              </option>
+              {registry.map((stepType) => (
+                <StepTypeOption key={stepType.id} stepType={stepType} />
+              ))}
+            </select>
+          </div>
+          {selectedPublishStepType ? (
+            <form className="space-y-3" data-testid="publish-form" onSubmit={submitPublish}>
+              <div className="grid gap-2">
+                <label className="text-sm font-medium text-gray-700" htmlFor="publish-version">
+                  Version
+                </label>
+                <select
+                  id="publish-version"
+                  value={publishForm.version}
+                  onChange={(event) => setPublishForm((prev) => ({ ...prev, version: event.target.value }))}
+                  required
+                  data-testid="publish-version-select"
+                  className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                  <option value="" disabled>
+                    Select a version
+                  </option>
+                  {resolveVersionForStepType(versions, registry, publishStepTypeId).map((version) => (
+                    <option key={version.id} value={version.id}>
+                      {version.version} ({version.status})
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="grid gap-2">
+                <label className="text-sm font-medium text-gray-700" htmlFor="publish-changelog">
+                  Changelog
+                </label>
+                <textarea
+                  id="publish-changelog"
+                  value={publishForm.changelog}
+                  onChange={(event) => setPublishForm((prev) => ({ ...prev, changelog: event.target.value }))}
+                  rows={3}
+                  className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+              <div className="grid gap-2">
+                <label className="text-sm font-medium text-gray-700" htmlFor="publish-reason">
+                  Reason code
+                </label>
+                <textarea
+                  id="publish-reason"
+                  value={publishForm.reason}
+                  onChange={(event) => setPublishForm((prev) => ({ ...prev, reason: event.target.value }))}
+                  required
+                  rows={2}
+                  className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+              <button
+                type="submit"
+                disabled={publishMutation.submitting}
+                className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
+              >
+                {publishMutation.submitting ? "Publishing…" : "Publish version"}
+              </button>
+            </form>
+          ) : (
+            <p className="text-sm text-gray-500">Select a step type to publish.</p>
+          )}
+          <ApiResultCallout result={publishMutation.result} error={publishMutation.error} />
+        </div>
+
+        <div className="space-y-4 rounded-lg border border-gray-200 p-4">
+          <header className="space-y-1">
+            <h3 className="text-base font-semibold text-gray-900">Enable tenant</h3>
+            <p className="text-sm text-gray-600">
+              Install a step type for a tenant and optionally follow latest versions. {installTenantCount} tenants currently have
+              installs.
+            </p>
+          </header>
+          <div className="grid gap-2">
+            <label className="text-sm font-medium text-gray-700" htmlFor="install-step-type">
+              Step type
+            </label>
+            <select
+              id="install-step-type"
+              value={installStepTypeId ?? ""}
+              onChange={(event) => setInstallStepTypeId(event.target.value)}
+              data-testid="install-step-type-select"
+              className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="" disabled>
+                Select a step type
+              </option>
+              {registry.map((stepType) => (
+                <StepTypeOption key={stepType.id} stepType={stepType} />
+              ))}
+            </select>
+          </div>
+          {selectedInstallStepType ? (
+            <form className="space-y-3" data-testid="install-form" onSubmit={submitInstall}>
+              <div className="grid gap-2">
+                <label className="text-sm font-medium text-gray-700" htmlFor="install-org">
+                  Tenant organisation slug
+                </label>
+                <input
+                  id="install-org"
+                  value={installForm.orgSlug}
+                  onChange={(event) => setInstallForm((prev) => ({ ...prev, orgSlug: event.target.value }))}
+                  required
+                  className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+              <div className="grid gap-2">
+                <label className="text-sm font-medium text-gray-700" htmlFor="install-version">
+                  Version
+                </label>
+                <select
+                  id="install-version"
+                  value={installForm.versionId}
+                  onChange={(event) => setInstallForm((prev) => ({ ...prev, versionId: event.target.value }))}
+                  required={!installForm.followLatest}
+                  data-testid="install-version-select"
+                  className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                  <option value="" disabled>
+                    Select a version
+                  </option>
+                  {installVersionOptions.map((version) => (
+                    <option key={version.id} value={version.id}>
+                      {version.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <label className="flex items-center gap-2 text-sm text-gray-700">
+                <input
+                  type="checkbox"
+                  checked={installForm.followLatest}
+                  onChange={(event) =>
+                    setInstallForm((prev) => ({
+                      ...prev,
+                      followLatest: event.target.checked,
+                    }))
+                  }
+                  className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                />
+                Follow latest version automatically
+              </label>
+              <div className="grid gap-2">
+                <label className="text-sm font-medium text-gray-700" htmlFor="install-reason">
+                  Reason code
+                </label>
+                <textarea
+                  id="install-reason"
+                  value={installForm.reason}
+                  onChange={(event) => setInstallForm((prev) => ({ ...prev, reason: event.target.value }))}
+                  required
+                  rows={2}
+                  className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+              <button
+                type="submit"
+                disabled={installMutation.submitting}
+                className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
+              >
+                {installMutation.submitting ? "Enabling…" : "Enable tenant"}
+              </button>
+            </form>
+          ) : (
+            <p className="text-sm text-gray-500">Select a step type to manage installs.</p>
+          )}
+          <ApiResultCallout result={installMutation.result} error={installMutation.error} />
+        </div>
+
+        <div className="space-y-4 rounded-lg border border-gray-200 p-4">
+          <header className="space-y-1">
+            <h3 className="text-base font-semibold text-gray-900">Bind secret alias</h3>
+            <p className="text-sm text-gray-600">
+              Associate a secret alias with a tenant install for runtime credentials. {bindingTenantCount} tenants currently have
+              bindings.
+            </p>
+          </header>
+          <div className="grid gap-2">
+            <label className="text-sm font-medium text-gray-700" htmlFor="binding-step-type">
+              Step type
+            </label>
+            <select
+              id="binding-step-type"
+              value={bindingStepTypeId ?? ""}
+              onChange={(event) => setBindingStepTypeId(event.target.value)}
+              className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="" disabled>
+                Select a step type
+              </option>
+              {registry.map((stepType) => (
+                <StepTypeOption key={stepType.id} stepType={stepType} />
+              ))}
+            </select>
+          </div>
+          {selectedBindingStepType ? (
+            <form className="space-y-3" onSubmit={submitBinding}>
+              <div className="grid gap-2">
+                <label className="text-sm font-medium text-gray-700" htmlFor="binding-org">
+                  Tenant organisation slug
+                </label>
+                <input
+                  id="binding-org"
+                  value={bindingForm.orgSlug}
+                  onChange={(event) => setBindingForm((prev) => ({ ...prev, orgSlug: event.target.value }))}
+                  required
+                  className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+              <div className="grid gap-2">
+                <label className="text-sm font-medium text-gray-700" htmlFor="binding-alias">
+                  Secret alias
+                </label>
+                <input
+                  id="binding-alias"
+                  value={bindingForm.alias}
+                  onChange={(event) => setBindingForm((prev) => ({ ...prev, alias: event.target.value }))}
+                  required
+                  pattern="^secrets\\.[a-zA-Z0-9_.:-]+$"
+                  placeholder="secrets.example.apiKey"
+                  className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+              <div className="grid gap-2">
+                <label className="text-sm font-medium text-gray-700" htmlFor="binding-provider">
+                  Provider
+                </label>
+                <select
+                  id="binding-provider"
+                  value={bindingForm.provider}
+                  onChange={(event) => setBindingForm((prev) => ({ ...prev, provider: event.target.value }))}
+                  className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                  {providers.map((provider) => (
+                    <option key={provider.value} value={provider.value}>
+                      {provider.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="grid gap-2">
+                <label className="text-sm font-medium text-gray-700" htmlFor="binding-external-id">
+                  Provider reference
+                </label>
+                <input
+                  id="binding-external-id"
+                  value={bindingForm.externalId}
+                  onChange={(event) => setBindingForm((prev) => ({ ...prev, externalId: event.target.value }))}
+                  required
+                  className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+              <div className="grid gap-2">
+                <label className="text-sm font-medium text-gray-700" htmlFor="binding-reason">
+                  Reason code
+                </label>
+                <textarea
+                  id="binding-reason"
+                  value={bindingForm.reason}
+                  onChange={(event) => setBindingForm((prev) => ({ ...prev, reason: event.target.value }))}
+                  required
+                  rows={2}
+                  className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+              <button
+                type="submit"
+                disabled={bindingMutation.submitting}
+                className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
+              >
+                {bindingMutation.submitting ? "Binding…" : "Bind secret alias"}
+              </button>
+            </form>
+          ) : (
+            <p className="text-sm text-gray-500">Select a step type to manage secret bindings.</p>
+          )}
+          <ApiResultCallout result={bindingMutation.result} error={bindingMutation.error} />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/admin/src/app/[locale]/step-types/step-type-actions.tsx
+++ b/apps/admin/src/app/[locale]/step-types/step-type-actions.tsx
@@ -1,0 +1,35 @@
+import { Card, Flex, Heading, Text } from "@radix-ui/themes";
+import type {
+  StepTypeRegistryEntry,
+  StepTypeVersionLedgerEntry,
+  TenantSecretBinding,
+  TenantStepTypeInstall,
+} from "./types";
+import { StepTypeActionsClient } from "./step-type-actions.client";
+
+export interface StepTypeActionsProps {
+  registry: StepTypeRegistryEntry[];
+  versions: StepTypeVersionLedgerEntry[];
+  tenantInstalls: TenantStepTypeInstall[];
+  secretBindings: TenantSecretBinding[];
+}
+
+export function StepTypeActions(props: StepTypeActionsProps) {
+  if (props.registry.length === 0 && props.versions.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card variant="surface">
+      <Flex direction="column" gap="4">
+        <header>
+          <Heading size="5">Step type controls</Heading>
+          <Text size="2" color="gray">
+            Create and publish step types, manage tenant enablement, and bind secret aliases.
+          </Text>
+        </header>
+        <StepTypeActionsClient {...props} />
+      </Flex>
+    </Card>
+  );
+}

--- a/apps/admin/src/app/[locale]/step-types/types.ts
+++ b/apps/admin/src/app/[locale]/step-types/types.ts
@@ -1,0 +1,58 @@
+export interface StepTypeRegistryEntry {
+  id: string;
+  slug: string;
+  title: string;
+  category: string;
+  latest_version: string;
+  summary: string | null;
+  published_versions: number;
+}
+
+export interface StepTypeVersionLedgerEntry {
+  id: string;
+  step_type_slug: string;
+  version: string;
+  status: "draft" | "published" | "archived" | string;
+  published_at: string | null;
+  schema_slug: string | null;
+}
+
+export interface TenantStepTypeInstall {
+  id: string;
+  tenant_name: string;
+  org_slug: string;
+  step_type_version: string;
+  status: "enabled" | "disabled" | string;
+  installed_at: string | null;
+}
+
+export interface TenantSecretBinding {
+  id: string;
+  tenant_name: string;
+  alias: string;
+  provider: string;
+  external_id: string;
+  last_verified_at?: string | null;
+}
+
+export interface WorkflowOverlaySnapshot {
+  id: string;
+  workflow_slug: string;
+  tenant_name: string;
+  overlay_count: number;
+  created_at: string;
+}
+
+export interface MutationResponse {
+  audit_id?: string | null;
+  reason_code?: string | null;
+  warnings?: string[];
+  validation_errors?: string[];
+}
+
+export interface ApiErrorShape {
+  error: string;
+  details?: string | null;
+  validationErrors?: string[] | null;
+  auditId?: string | null;
+}

--- a/apps/admin/src/app/api/admin/step-types/[stepTypeId]/publish/route.ts
+++ b/apps/admin/src/app/api/admin/step-types/[stepTypeId]/publish/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import { callAdminRpc, jsonError, resolveAdminContext } from "../../_utils";
+
+interface PublishPayload {
+  reason?: string;
+  version?: string;
+  changelog?: string;
+}
+
+export async function POST(request: Request, { params }: { params: { stepTypeId: string } }) {
+  const context = await resolveAdminContext();
+  if (context instanceof NextResponse) {
+    return context;
+  }
+
+  const stepTypeId = params.stepTypeId;
+  if (!stepTypeId) {
+    return jsonError(400, "Step type id is required");
+  }
+
+  let payload: PublishPayload;
+  try {
+    payload = (await request.json()) as PublishPayload;
+  } catch (error) {
+    return jsonError(400, "Invalid JSON body");
+  }
+
+  if (!payload.reason || !payload.reason.trim()) {
+    return jsonError(422, "Reason code is required", { validationErrors: ["Reason code is required"] });
+  }
+
+  if (!payload.version) {
+    return jsonError(422, "Version identifier is required");
+  }
+
+  try {
+    const result = await callAdminRpc<Record<string, unknown>>("admin_publish_step_type_version", {
+      reason: payload.reason,
+      actor_id: context.userId,
+      step_type_id: stepTypeId,
+      version_id: payload.version,
+      changelog: payload.changelog ?? null,
+    });
+
+    return NextResponse.json({
+      message: "Step type version published",
+      auditId: result?.audit_id ?? null,
+      data: result,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unable to publish version";
+    const details = error instanceof Error && "details" in error ? (error as { details?: string }).details : undefined;
+    return jsonError(400, message, details ? { details } : undefined);
+  }
+}

--- a/apps/admin/src/app/api/admin/step-types/[stepTypeId]/secret-bindings/[bindingId]/route.ts
+++ b/apps/admin/src/app/api/admin/step-types/[stepTypeId]/secret-bindings/[bindingId]/route.ts
@@ -1,0 +1,106 @@
+import { NextResponse } from "next/server";
+import { callAdminRpc, jsonError, resolveAdminContext } from "../../../_utils";
+
+interface UpdateBindingPayload {
+  reason?: string;
+  patch?: {
+    alias?: string;
+    provider?: string;
+    external_id?: string;
+  };
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: { stepTypeId: string; bindingId: string } }
+) {
+  const context = await resolveAdminContext();
+  if (context instanceof NextResponse) {
+    return context;
+  }
+
+  const { stepTypeId, bindingId } = params;
+  if (!stepTypeId || !bindingId) {
+    return jsonError(400, "Step type id and binding id are required");
+  }
+
+  let payload: UpdateBindingPayload;
+  try {
+    payload = (await request.json()) as UpdateBindingPayload;
+  } catch (error) {
+    return jsonError(400, "Invalid JSON body");
+  }
+
+  if (!payload.reason || !payload.reason.trim()) {
+    return jsonError(422, "Reason code is required", { validationErrors: ["Reason code is required"] });
+  }
+
+  if (!payload.patch) {
+    return jsonError(422, "Binding patch payload is required");
+  }
+
+  try {
+    const result = await callAdminRpc<Record<string, unknown>>("admin_update_tenant_secret_binding", {
+      reason: payload.reason,
+      actor_id: context.userId,
+      step_type_id: stepTypeId,
+      binding_id: bindingId,
+      patch: payload.patch,
+    });
+
+    return NextResponse.json({
+      message: "Secret binding updated",
+      auditId: result?.audit_id ?? null,
+      data: result,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unable to update secret binding";
+    const details = error instanceof Error && "details" in error ? (error as { details?: string }).details : undefined;
+    return jsonError(400, message, details ? { details } : undefined);
+  }
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: { stepTypeId: string; bindingId: string } }
+) {
+  const context = await resolveAdminContext();
+  if (context instanceof NextResponse) {
+    return context;
+  }
+
+  const { stepTypeId, bindingId } = params;
+  if (!stepTypeId || !bindingId) {
+    return jsonError(400, "Step type id and binding id are required");
+  }
+
+  let payload: { reason?: string };
+  try {
+    payload = (await request.json()) as { reason?: string };
+  } catch (error) {
+    payload = {};
+  }
+
+  if (!payload.reason || !payload.reason.trim()) {
+    return jsonError(422, "Reason code is required", { validationErrors: ["Reason code is required"] });
+  }
+
+  try {
+    const result = await callAdminRpc<Record<string, unknown>>("admin_unbind_tenant_secret_alias", {
+      reason: payload.reason,
+      actor_id: context.userId,
+      step_type_id: stepTypeId,
+      binding_id: bindingId,
+    });
+
+    return NextResponse.json({
+      message: "Secret binding removed",
+      auditId: result?.audit_id ?? null,
+      data: result,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unable to remove secret binding";
+    const details = error instanceof Error && "details" in error ? (error as { details?: string }).details : undefined;
+    return jsonError(400, message, details ? { details } : undefined);
+  }
+}

--- a/apps/admin/src/app/api/admin/step-types/[stepTypeId]/secret-bindings/route.ts
+++ b/apps/admin/src/app/api/admin/step-types/[stepTypeId]/secret-bindings/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server";
+import { callAdminRpc, jsonError, resolveAdminContext } from "../../_utils";
+
+interface BindingPayload {
+  reason?: string;
+  binding?: {
+    org_slug?: string;
+    alias?: string;
+    provider?: string;
+    external_id?: string;
+  };
+}
+
+export async function POST(request: Request, { params }: { params: { stepTypeId: string } }) {
+  const context = await resolveAdminContext();
+  if (context instanceof NextResponse) {
+    return context;
+  }
+
+  const stepTypeId = params.stepTypeId;
+  if (!stepTypeId) {
+    return jsonError(400, "Step type id is required");
+  }
+
+  let payload: BindingPayload;
+  try {
+    payload = (await request.json()) as BindingPayload;
+  } catch (error) {
+    return jsonError(400, "Invalid JSON body");
+  }
+
+  if (!payload.reason || !payload.reason.trim()) {
+    return jsonError(422, "Reason code is required", { validationErrors: ["Reason code is required"] });
+  }
+
+  const binding = payload.binding ?? {};
+  if (!binding.org_slug || !binding.alias || !binding.provider || !binding.external_id) {
+    return jsonError(422, "Binding org, alias, provider, and reference are required");
+  }
+
+  try {
+    const result = await callAdminRpc<Record<string, unknown>>("admin_bind_tenant_secret_alias", {
+      reason: payload.reason,
+      actor_id: context.userId,
+      step_type_id: stepTypeId,
+      org_slug: binding.org_slug,
+      alias: binding.alias,
+      provider: binding.provider,
+      external_id: binding.external_id,
+    });
+
+    return NextResponse.json({
+      message: "Secret alias bound",
+      auditId: result?.audit_id ?? null,
+      data: result,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unable to bind secret alias";
+    const details = error instanceof Error && "details" in error ? (error as { details?: string }).details : undefined;
+    return jsonError(400, message, details ? { details } : undefined);
+  }
+}

--- a/apps/admin/src/app/api/admin/step-types/[stepTypeId]/tenants/[installId]/route.ts
+++ b/apps/admin/src/app/api/admin/step-types/[stepTypeId]/tenants/[installId]/route.ts
@@ -1,0 +1,110 @@
+import { NextResponse } from "next/server";
+import { callAdminRpc, jsonError, resolveAdminContext } from "../../../_utils";
+
+interface UpdateInstallPayload {
+  reason?: string;
+  patch?: {
+    follow_latest?: boolean;
+    version_id?: string | null;
+    status?: string;
+  };
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: { stepTypeId: string; installId: string } }
+) {
+  const context = await resolveAdminContext();
+  if (context instanceof NextResponse) {
+    return context;
+  }
+
+  const stepTypeId = params.stepTypeId;
+  const installId = params.installId;
+
+  if (!stepTypeId || !installId) {
+    return jsonError(400, "Step type id and install id are required");
+  }
+
+  let payload: UpdateInstallPayload;
+  try {
+    payload = (await request.json()) as UpdateInstallPayload;
+  } catch (error) {
+    return jsonError(400, "Invalid JSON body");
+  }
+
+  if (!payload.reason || !payload.reason.trim()) {
+    return jsonError(422, "Reason code is required", { validationErrors: ["Reason code is required"] });
+  }
+
+  if (!payload.patch) {
+    return jsonError(422, "Install patch payload is required");
+  }
+
+  try {
+    const result = await callAdminRpc<Record<string, unknown>>("admin_update_tenant_step_type_install", {
+      reason: payload.reason,
+      actor_id: context.userId,
+      step_type_id: stepTypeId,
+      install_id: installId,
+      patch: payload.patch,
+    });
+
+    return NextResponse.json({
+      message: "Tenant install updated",
+      auditId: result?.audit_id ?? null,
+      data: result,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unable to update tenant install";
+    const details = error instanceof Error && "details" in error ? (error as { details?: string }).details : undefined;
+    return jsonError(400, message, details ? { details } : undefined);
+  }
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: { stepTypeId: string; installId: string } }
+) {
+  const context = await resolveAdminContext();
+  if (context instanceof NextResponse) {
+    return context;
+  }
+
+  const stepTypeId = params.stepTypeId;
+  const installId = params.installId;
+
+  if (!stepTypeId || !installId) {
+    return jsonError(400, "Step type id and install id are required");
+  }
+
+  let payload: { reason?: string };
+  try {
+    payload = (await request.json()) as { reason?: string };
+  } catch (error) {
+    payload = {};
+  }
+
+  if (!payload.reason || !payload.reason.trim()) {
+    return jsonError(422, "Reason code is required", { validationErrors: ["Reason code is required"] });
+  }
+
+  try {
+    const result = await callAdminRpc<Record<string, unknown>>("admin_disable_tenant_step_type", {
+      reason: payload.reason,
+      actor_id: context.userId,
+      step_type_id: stepTypeId,
+      install_id: installId,
+    });
+
+    return NextResponse.json({
+      message: "Tenant install disabled",
+      auditId: result?.audit_id ?? null,
+      data: result,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unable to disable tenant install";
+    const details = error instanceof Error && "details" in error ? (error as { details?: string }).details : undefined;
+    return jsonError(400, message, details ? { details } : undefined);
+  }
+}

--- a/apps/admin/src/app/api/admin/step-types/[stepTypeId]/tenants/route.ts
+++ b/apps/admin/src/app/api/admin/step-types/[stepTypeId]/tenants/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+import { callAdminRpc, jsonError, resolveAdminContext } from "../../_utils";
+
+interface InstallPayload {
+  reason?: string;
+  install?: {
+    org_slug?: string;
+    version_id?: string;
+    follow_latest?: boolean;
+  };
+}
+
+export async function POST(request: Request, { params }: { params: { stepTypeId: string } }) {
+  const context = await resolveAdminContext();
+  if (context instanceof NextResponse) {
+    return context;
+  }
+
+  const stepTypeId = params.stepTypeId;
+  if (!stepTypeId) {
+    return jsonError(400, "Step type id is required");
+  }
+
+  let payload: InstallPayload;
+  try {
+    payload = (await request.json()) as InstallPayload;
+  } catch (error) {
+    return jsonError(400, "Invalid JSON body");
+  }
+
+  if (!payload.reason || !payload.reason.trim()) {
+    return jsonError(422, "Reason code is required", { validationErrors: ["Reason code is required"] });
+  }
+
+  const install = payload.install ?? {};
+  if (!install.org_slug) {
+    return jsonError(422, "Organisation slug is required");
+  }
+
+  if (!install.follow_latest && !install.version_id) {
+    return jsonError(422, "Version id is required when not following latest");
+  }
+
+  try {
+    const result = await callAdminRpc<Record<string, unknown>>("admin_enable_tenant_step_type", {
+      reason: payload.reason,
+      actor_id: context.userId,
+      step_type_id: stepTypeId,
+      org_slug: install.org_slug,
+      version_id: install.version_id ?? null,
+      follow_latest: install.follow_latest ?? false,
+    });
+
+    return NextResponse.json({
+      message: "Tenant step type installed",
+      auditId: result?.audit_id ?? null,
+      data: result,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unable to enable tenant";
+    const details = error instanceof Error && "details" in error ? (error as { details?: string }).details : undefined;
+    return jsonError(400, message, details ? { details } : undefined);
+  }
+}

--- a/apps/admin/src/app/api/admin/step-types/_utils.ts
+++ b/apps/admin/src/app/api/admin/step-types/_utils.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@airnub/types";
+import { getSupabaseUser } from "../../../../../lib/auth/supabase-ssr";
+import { getSupabaseServiceRoleClient } from "../../../../../lib/auth/supabase-service-role";
+import { requireRole, type AdminRole } from "../../../../../lib/rbac";
+
+export interface AdminApiContext {
+  userId: string;
+  email: string;
+  role: AdminRole;
+}
+
+interface RpcResponse<T> {
+  data: T | null;
+  error: { message: string; details?: string | null; hint?: string | null } | null;
+}
+
+export async function resolveAdminContext(): Promise<AdminApiContext | NextResponse> {
+  const user = await getSupabaseUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const role = (user.app_metadata?.admin_role ?? user.user_metadata?.admin_role) as AdminRole | undefined;
+  if (!role) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  try {
+    requireRole({ role }, ["platform_admin", "support_agent"]);
+  } catch (error) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  return { userId: user.id, email: user.email ?? "unknown", role };
+}
+
+export function jsonError(status: number, message: string, details?: Record<string, unknown>) {
+  return NextResponse.json({ error: message, ...details }, { status });
+}
+
+export function getAdminServiceRoleClient(): SupabaseClient<Database> {
+  return getSupabaseServiceRoleClient();
+}
+
+export async function callAdminRpc<T>(procedure: string, params: Record<string, unknown>): Promise<T> {
+  const client = getAdminServiceRoleClient();
+  const { data, error } = (await client.rpc<T>(procedure, params)) as RpcResponse<T>;
+
+  if (error) {
+    const details = error.details ? { details: error.details } : undefined;
+    throw Object.assign(new Error(error.message), details ?? {});
+  }
+
+  return (data ?? {}) as T;
+}

--- a/apps/admin/src/app/api/admin/step-types/route.ts
+++ b/apps/admin/src/app/api/admin/step-types/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { callAdminRpc, jsonError, resolveAdminContext } from "./_utils";
+
+interface CreateStepTypePayload {
+  reason?: string;
+  stepType?: Record<string, unknown>;
+}
+
+export async function POST(request: Request) {
+  const context = await resolveAdminContext();
+  if (context instanceof NextResponse) {
+    return context;
+  }
+
+  let payload: CreateStepTypePayload;
+  try {
+    payload = (await request.json()) as CreateStepTypePayload;
+  } catch (error) {
+    return jsonError(400, "Invalid JSON body");
+  }
+
+  if (!payload.reason || !payload.reason.trim()) {
+    return jsonError(422, "Reason code is required", { validationErrors: ["Reason code is required"] });
+  }
+
+  if (!payload.stepType) {
+    return jsonError(422, "Step type definition is required");
+  }
+
+  try {
+    const result = await callAdminRpc<Record<string, unknown>>("admin_create_step_type", {
+      reason: payload.reason,
+      actor_id: context.userId,
+      step_type: payload.stepType,
+    });
+
+    return NextResponse.json({
+      message: "Step type draft created",
+      auditId: result?.audit_id ?? null,
+      data: result,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unable to create step type";
+    const details = error instanceof Error && "details" in error ? (error as { details?: string }).details : undefined;
+    return jsonError(400, message, details ? { details } : undefined);
+  }
+}

--- a/apps/admin/src/components/ApiResultCallout.tsx
+++ b/apps/admin/src/components/ApiResultCallout.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+
+interface ApiResultCalloutProps {
+  result?: { message: string; auditId?: string | null; warnings?: string[] } | null;
+  error?: { message: string; details?: string | null; validationErrors?: string[] | null } | null;
+}
+
+export function ApiResultCallout({ result, error }: ApiResultCalloutProps) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (result || error) {
+      setVisible(true);
+    }
+  }, [result, error]);
+
+  if (!visible || (!result && !error)) {
+    return null;
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800" role="alert">
+        <p className="font-semibold">{error.message}</p>
+        {error.details ? <p className="mt-1">{error.details}</p> : null}
+        {error.validationErrors?.length ? (
+          <ul className="mt-2 list-disc space-y-1 pl-5">
+            {error.validationErrors.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (!result) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-md border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-900" role="status">
+      <p className="font-semibold">{result.message}</p>
+      {result.auditId ? <p className="mt-1 text-xs">Audit reference: {result.auditId}</p> : null}
+      {result.warnings?.length ? (
+        <ul className="mt-2 list-disc space-y-1 pl-5 text-emerald-800">
+          {result.warnings.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/admin/src/lib/__tests__/rbac.test.ts
+++ b/apps/admin/src/lib/__tests__/rbac.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  canApproveSecond,
+  canEditStep,
+  isElevated,
+  requireRole,
+  requiresSecondApproval,
+  type AdminRole,
+} from "../rbac";
+
+describe("rbac helpers", () => {
+  it("allows permitted roles to edit steps", () => {
+    expect(canEditStep({ role: "platform_admin" })).toBe(true);
+    expect(canEditStep({ role: "support_agent" })).toBe(true);
+  });
+
+  it("blocks disallowed roles from editing steps", () => {
+    expect(canEditStep({ role: "compliance_moderator" as AdminRole })).toBe(false);
+  });
+
+  it("requires second approval for high-risk actions", () => {
+    expect(requiresSecondApproval("cancel_workflow")).toBe(true);
+    expect(requiresSecondApproval("delete_record")).toBe(true);
+    expect(requiresSecondApproval("other")).toBe(false);
+  });
+
+  it("permits elevated roles", () => {
+    expect(isElevated({ role: "platform_admin" })).toBe(true);
+    expect(isElevated({ role: "support_agent" as AdminRole })).toBe(false);
+  });
+
+  it("validates role requirements", () => {
+    expect(() => requireRole({ role: "platform_admin" }, ["platform_admin"])).not.toThrow();
+    expect(() => requireRole({ role: "support_agent" }, ["platform_admin"])).toThrow();
+  });
+
+  it("checks approval capabilities", () => {
+    expect(canApproveSecond({ role: "platform_admin" })).toBe(true);
+    expect(canApproveSecond({ role: "dpo" })).toBe(true);
+    expect(canApproveSecond({ role: "support_agent" })).toBe(false);
+  });
+});

--- a/apps/admin/src/lib/auth/supabase-service-role.ts
+++ b/apps/admin/src/lib/auth/supabase-service-role.ts
@@ -1,0 +1,47 @@
+import { createClient } from "@supabase/supabase-js";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@airnub/types";
+
+let cachedClient: SupabaseClient<Database> | null = null;
+
+class SupabaseServiceRoleConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SupabaseServiceRoleConfigurationError";
+  }
+}
+
+function resolveServiceRoleEnv() {
+  const url = process.env.SUPABASE_SERVICE_ROLE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url) {
+    throw new SupabaseServiceRoleConfigurationError(
+      "Supabase service role URL is not configured. Set SUPABASE_SERVICE_ROLE_URL or NEXT_PUBLIC_SUPABASE_URL."
+    );
+  }
+
+  if (!serviceRoleKey) {
+    throw new SupabaseServiceRoleConfigurationError(
+      "Supabase service role key is not configured. Set SUPABASE_SERVICE_ROLE_KEY."
+    );
+  }
+
+  return { url, serviceRoleKey };
+}
+
+export function getSupabaseServiceRoleClient(): SupabaseClient<Database> {
+  if (!cachedClient) {
+    const { url, serviceRoleKey } = resolveServiceRoleEnv();
+    cachedClient = createClient<Database>(url, serviceRoleKey, {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+      },
+    });
+  }
+
+  return cachedClient;
+}
+
+export { SupabaseServiceRoleConfigurationError };

--- a/apps/admin/vitest.config.ts
+++ b/apps/admin/vitest.config.ts
@@ -1,0 +1,19 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const srcDir = fileURLToPath(new URL("./src", import.meta.url));
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": srcDir,
+    },
+  },
+  test: {
+    environment: "happy-dom",
+    setupFiles: "./vitest.setup.ts",
+    coverage: {
+      reporter: ["text", "lcov"],
+    },
+  },
+});

--- a/apps/admin/vitest.setup.ts
+++ b/apps/admin/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";


### PR DESCRIPTION
## Summary
- replace the step type overview with server-side loaders backed by Supabase service-role RPCs and surface the new StepTypeActions control panel
- add authenticated admin API routes for creating, updating, publishing, installing, and binding step types with reason code enforcement and audit propagation
- build client dialogs/forms plus reusable callout UI for registry actions and cover the flows with Vitest-based integration and RBAC unit tests

## Testing
- pnpm --filter @airnub/admin test

------
https://chatgpt.com/codex/tasks/task_e_68dfdf12ad188324964341f1ae845c53