### PR TITLE
feat: add external execution modes for tenant overlays

### DIFF
--- a/apps/portal/messages/en-IE/common.json
+++ b/apps/portal/messages/en-IE/common.json
@@ -99,12 +99,16 @@
     "orchestrationDescription": "Launch Temporal workflows, send signals, or capture manual updates for each step.",
     "orchestrationTemporalHint": "Temporal worker handles retries and polling.",
     "orchestrationManualHint": "Manual execution tracked via calendar reminders and evidence uploads.",
+    "orchestrationWebhookHint": "Invoke signed tenant webhooks and review response hashes.",
     "orchestrationStart": "Start",
     "orchestrationRetry": "Retry",
     "orchestrationSignal": "Send signal",
     "orchestrationSignalSuccess": "Signal delivered to Temporal workflow.",
     "orchestrationManualButton": "Mark done / upload proof",
     "orchestrationManualComplete": "Marked complete — upload evidence via the panel above.",
+    "orchestrationWebhookButton": "Send webhook",
+    "orchestrationWebhookSuccess": "Webhook dispatched (status {status}).",
+    "orchestrationWebhookError": "Unable to invoke tenant webhook.",
     "orchestrationReceiptPlaceholder": "Receipt URL (optional)",
     "orchestrationReceiptLabel": "Receipt URL",
     "orchestrationStartSuccess": "Workflow started (ID: {workflowId})",
@@ -143,7 +147,22 @@
       "input": "Input JSON",
       "inputPlaceholder": "{ } // JSON payload for the step",
       "secret": "Secret alias",
-      "secretPlaceholder": "Select alias (optional)"
+      "secretPlaceholder": "Select alias (optional)",
+      "executionLabel": "Execution config",
+      "executionHint": "Configure runtime metadata for the selected step.",
+      "executionWebhookMethod": "HTTP method",
+      "executionWebhookUrlAlias": "Webhook URL alias",
+      "executionWebhookTokenAlias": "Auth token alias",
+      "executionWebhookPath": "Path (optional)",
+      "executionWebhookSigningAlias": "Signing secret alias",
+      "executionTemporalWorkflow": "Temporal workflow (override)",
+      "executionTemporalTaskQueue": "Task queue",
+      "executionTemporalDefaultTaskQueue": "Default task queue",
+      "executionWebsocketUrlAlias": "WebSocket URL alias",
+      "executionWebsocketTokenAlias": "Bearer token alias",
+      "executionWebsocketMessageSchema": "Message schema ID",
+      "executionWebsocketWorkflow": "Temporal workflow",
+      "executionWebsocketQueue": "Default task queue"
     },
     "actions": {
       "insert": "Insert step",
@@ -165,7 +184,11 @@
       "persistError": "Unable to persist overlay snapshot.",
       "mergeError": "Overlay merge failed",
       "secretRequired": "Select a secret alias before inserting this step.",
-      "secretUnavailable": "No eligible secret bindings are available for this step type."
+      "secretUnavailable": "No eligible secret bindings are available for this step type.",
+      "executionWebhookUrlAliasRequired": "Select a webhook URL alias before inserting this step.",
+      "executionWebsocketUrlAliasRequired": "Select a websocket URL alias before inserting this step.",
+      "executionAliasInvalid": "Alias values must reference secret bindings, not literal URLs.",
+      "executionAliasUnavailable": "No eligible secret aliases are available for this execution configuration."
     },
     "stepTypes": {
       "manualReview": {
@@ -175,11 +198,24 @@
       "temporalWebhook": {
         "title": "Temporal webhook bridge",
         "summary": "Trigger a tenant-specific Temporal workflow via signed webhook requests."
+      },
+      "externalWebhook": {
+        "title": "Tenant webhook call",
+        "summary": "Invoke an external webhook with alias-resolved credentials and signing." 
+      },
+      "externalWebsocket": {
+        "title": "WebSocket listener bridge",
+        "summary": "Listen to tenant event streams and route messages via Temporal workflows."
       }
     },
     "secrets": {
       "crmApiToken": "CRM API token resolved at runtime.",
-      "temporalQueue": "Temporal task queue signing key stored in vault."
+      "temporalQueue": "Temporal task queue signing key stored in vault.",
+      "webhookBaseUrl": "Tenant webhook base URL alias.",
+      "webhookToken": "Bearer token alias resolved per tenant.",
+      "webhookSignature": "Webhook signature secret alias resolved per tenant.",
+      "websocketUrl": "Tenant websocket endpoint alias.",
+      "websocketToken": "Websocket bearer token alias."
     }
   },
   "funding": {

--- a/apps/portal/messages/ga-IE/common.json
+++ b/apps/portal/messages/ga-IE/common.json
@@ -99,12 +99,16 @@
     "orchestrationDescription": "Seol sreafaí oibre Temporal, seol comharthaí, nó taifead nuashonruithe láimhe do gach céim.",
     "orchestrationTemporalHint": "Láimhseálann an t-oibrí Temporal athiarrachtaí agus póiliniú.",
     "orchestrationManualHint": "Rianaítear forghníomhú láimhe trí mheabhrúcháin féilire agus uaslódálacha fianaise.",
+    "orchestrationWebhookHint": "Seol webhook sínithe an tionanta agus féach ar hash na freagartha.",
     "orchestrationStart": "Tosaigh",
     "orchestrationRetry": "Athsheol",
     "orchestrationSignal": "Seol comhartha",
     "orchestrationSignalSuccess": "Seoladh an comhartha chuig Temporal.",
     "orchestrationManualButton": "Marcáil críochnaithe / uaslódáil cruthúnas",
     "orchestrationManualComplete": "Marcáilte críochnaithe — uaslódáil fianaise tríd an bpainéal thuas.",
+    "orchestrationWebhookButton": "Seol webhook",
+    "orchestrationWebhookSuccess": "Seoladh an webhook (stádas {status}).",
+    "orchestrationWebhookError": "Níor éirigh leis an webhook a sheoladh.",
     "orchestrationReceiptPlaceholder": "URL admhála (roghnach)",
     "orchestrationReceiptLabel": "URL admhála",
     "orchestrationStartSuccess": "Tosaíodh an sreabhadh oibre (ID: {workflowId})",
@@ -143,7 +147,22 @@
       "input": "JSON ionchuir",
       "inputPlaceholder": "{ } // Lódál JSON don chéim",
       "secret": "Ailias rúin",
-      "secretPlaceholder": "Roghnaigh ailias (roghnach)"
+      "secretPlaceholder": "Roghnaigh ailias (roghnach)",
+      "executionLabel": "Cumraíocht fhorghníomhaithe",
+      "executionHint": "Cumraigh meiteashonraí ama-rith don chéim roghnaithe.",
+      "executionWebhookMethod": "Modh HTTP",
+      "executionWebhookUrlAlias": "Ailias URL webhook",
+      "executionWebhookTokenAlias": "Ailias comhartha fíordheimhnithe",
+      "executionWebhookPath": "Cosán (roghnach)",
+      "executionWebhookSigningAlias": "Ailias rúin sínithe",
+      "executionTemporalWorkflow": "Sreabhadh Temporal (forscríobh)",
+      "executionTemporalTaskQueue": "Scuaine tasc",
+      "executionTemporalDefaultTaskQueue": "Réamhshocrú scuaine tasc",
+      "executionWebsocketUrlAlias": "Ailias URL WebSocket",
+      "executionWebsocketTokenAlias": "Ailias comhartha bearair",
+      "executionWebsocketMessageSchema": "ID scéime teachtaireachta",
+      "executionWebsocketWorkflow": "Sreabhadh Temporal",
+      "executionWebsocketQueue": "Réamhshocrú scuaine tasc"
     },
     "actions": {
       "insert": "Cuir céim isteach",
@@ -165,7 +184,11 @@
       "persistError": "Níor éirigh le snapshot forleagain a shábháil.",
       "mergeError": "Theip ar chumasc forleagain",
       "secretRequired": "Roghnaigh ailias rúin sula gcuirtear an chéim seo isteach.",
-      "secretUnavailable": "Níl aon cheangail rúin oiriúnacha ar fáil don chineál céime seo."
+      "secretUnavailable": "Níl aon cheangail rúin oiriúnacha ar fáil don chineál céime seo.",
+      "executionWebhookUrlAliasRequired": "Roghnaigh ailias URL webhook sula gcuirtear an chéim seo isteach.",
+      "executionWebsocketUrlAliasRequired": "Roghnaigh ailias URL WebSocket sula gcuirtear an chéim seo isteach.",
+      "executionAliasInvalid": "Ní mór ailiasanna tagairt a dhéanamh do cheangail rúin, ní URLanna litriúla.",
+      "executionAliasUnavailable": "Níl aon ailiasanna rúin oiriúnacha ar fáil don chumraíocht fhorghníomhaithe seo."
     },
     "stepTypes": {
       "manualReview": {
@@ -175,11 +198,24 @@
       "temporalWebhook": {
         "title": "Droichead webhook Temporal",
         "summary": "Cuir sreabhadh Temporal an tionant ar siúl trí iarrataí webhook sínithe."
+      },
+      "externalWebhook": {
+        "title": "Glao webhook tionant",
+        "summary": "Seol webhook seachtrach le haitheantas agus sínithe trí ailias."
+      },
+      "externalWebsocket": {
+        "title": "Droichead éisteachta WebSocket",
+        "summary": "Éist le sruthanna imeachtaí tionant agus atreoraigh teachtaireachtaí trí Temporal."
       }
     },
     "secrets": {
       "crmApiToken": "Comhartha API CRM réitithe ag am rith.",
-      "temporalQueue": "Eochair scuaine tasc Temporal stóráilte sa stór rúin."
+      "temporalQueue": "Eochair scuaine tasc Temporal stóráilte sa stór rúin.",
+      "webhookBaseUrl": "Ailias URL bunúsach webhook tionant.",
+      "webhookToken": "Ailias comhartha bearair tionant.",
+      "webhookSignature": "Ailias rúin sínithe webhook a réitítear do gach tionant.",
+      "websocketUrl": "Ailias deireadh WebSocket tionant.",
+      "websocketToken": "Ailias comhartha WebSocket."
     }
   },
   "funding": {

--- a/apps/portal/src/app/[locale]/(workflow)/overlay-builder/page.tsx
+++ b/apps/portal/src/app/[locale]/(workflow)/overlay-builder/page.tsx
@@ -41,7 +41,7 @@ export default async function OverlayBuilderPage({
       title: t("stepTypes.manualReview.title"),
       summary: t("stepTypes.manualReview.summary"),
       kind: "review",
-      executionMode: "manual" as const,
+      execution: { mode: "manual" as const },
       defaultInput: {
         checklist: ["evidence", "notes"],
       },
@@ -53,12 +53,67 @@ export default async function OverlayBuilderPage({
       title: t("stepTypes.temporalWebhook.title"),
       summary: t("stepTypes.temporalWebhook.summary"),
       kind: "tool.call",
-      executionMode: "temporal" as const,
+      execution: {
+        mode: "temporal" as const,
+        workflow: "croNameCheckWorkflow",
+        defaultTaskQueue: "fc-standard",
+        config: {
+          workflow: "croNameCheckWorkflow",
+          defaultTaskQueue: "fc-standard",
+        },
+      },
       defaultInput: {
-        urlAlias: "secrets.crm.apiToken",
         retryPolicy: { attempts: 3 },
       },
       secretAliases: ["secrets.crm.apiToken", "secrets.temporal.taskQueueKey"],
+    },
+    {
+      slug: "external.crm.webhook",
+      version: "1.0.0",
+      title: t("stepTypes.externalWebhook.title"),
+      summary: t("stepTypes.externalWebhook.summary"),
+      kind: "action",
+      execution: {
+        mode: "external:webhook" as const,
+        config: {
+          method: "POST",
+          urlAlias: "secrets.webhooks.baseUrl",
+          tokenAlias: "secrets.webhooks.token",
+          path: "/integrations/fresh-comply",
+        },
+      },
+      defaultInput: {
+        payloadTemplate: { status: "pending" },
+      },
+      secretAliases: ["secrets.webhooks.baseUrl", "secrets.webhooks.token", "secrets.webhooks.signature"],
+      executionAliasOptions: {
+        urlAlias: ["secrets.webhooks.baseUrl"],
+        tokenAlias: ["secrets.webhooks.token"],
+        "signing.secretAlias": ["secrets.webhooks.signature"],
+      },
+    },
+    {
+      slug: "external.stream.websocket",
+      version: "0.3.0",
+      title: t("stepTypes.externalWebsocket.title"),
+      summary: t("stepTypes.externalWebsocket.summary"),
+      kind: "tool.call",
+      execution: {
+        mode: "external:websocket" as const,
+        config: {
+          urlAlias: "secrets.websocket.baseUrl",
+          tokenAlias: "secrets.websocket.token",
+          messageSchema: "schemas/stream-message.json",
+          temporalWorkflow: "externalJobWorkflow",
+          defaultTaskQueue: "tenant-x-events",
+        },
+      },
+      defaultInput: {},
+      secretAliases: ["secrets.websocket.baseUrl", "secrets.websocket.token"],
+      executionAliasOptions: {
+        urlAlias: ["secrets.websocket.baseUrl"],
+        tokenAlias: ["secrets.websocket.token"],
+      },
     },
   ];
 
@@ -70,6 +125,26 @@ export default async function OverlayBuilderPage({
     {
       alias: "secrets.temporal.taskQueueKey",
       description: t("secrets.temporalQueue"),
+    },
+    {
+      alias: "secrets.webhooks.baseUrl",
+      description: t("secrets.webhookBaseUrl"),
+    },
+    {
+      alias: "secrets.webhooks.token",
+      description: t("secrets.webhookToken"),
+    },
+    {
+      alias: "secrets.webhooks.signature",
+      description: t("secrets.webhookSignature"),
+    },
+    {
+      alias: "secrets.websocket.baseUrl",
+      description: t("secrets.websocketUrl"),
+    },
+    {
+      alias: "secrets.websocket.token",
+      description: t("secrets.websocketToken"),
     },
   ];
 
@@ -85,6 +160,22 @@ export default async function OverlayBuilderPage({
     inputPlaceholder: t("add.inputPlaceholder"),
     secretLabel: t("add.secret"),
     secretPlaceholder: t("add.secretPlaceholder"),
+    executionLabel: t("add.executionLabel"),
+    executionHint: t("add.executionHint"),
+    executionWebhookMethod: t("add.executionWebhookMethod"),
+    executionWebhookUrlAlias: t("add.executionWebhookUrlAlias"),
+    executionWebhookTokenAlias: t("add.executionWebhookTokenAlias"),
+    executionWebhookPath: t("add.executionWebhookPath"),
+    executionWebhookSigningAlias: t("add.executionWebhookSigningAlias"),
+    executionTemporalWorkflow: t("add.executionTemporalWorkflow"),
+    executionTemporalTaskQueue: t("add.executionTemporalTaskQueue"),
+    executionTemporalDefaultTaskQueue: t("add.executionTemporalDefaultTaskQueue"),
+    executionWebsocketUrlAlias: t("add.executionWebsocketUrlAlias"),
+    executionWebsocketTokenAlias: t("add.executionWebsocketTokenAlias"),
+    executionWebsocketMessageSchema: t("add.executionWebsocketMessageSchema"),
+    executionWebsocketWorkflow: t("add.executionWebsocketWorkflow"),
+    executionWebsocketQueue: t("add.executionWebsocketQueue"),
+    executionAliasUnavailable: t("messages.executionAliasUnavailable"),
     insertButton: t("actions.insert"),
     resetButton: t("actions.reset"),
     operationsHeading: t("operations.heading"),
@@ -96,6 +187,9 @@ export default async function OverlayBuilderPage({
     mergeError: t("messages.mergeError"),
     secretRequired: t("messages.secretRequired"),
     secretUnavailable: t("messages.secretUnavailable"),
+    executionWebhookUrlAliasRequired: t("messages.executionWebhookUrlAliasRequired"),
+    executionWebsocketUrlAliasRequired: t("messages.executionWebsocketUrlAliasRequired"),
+    executionAliasInvalid: t("messages.executionAliasInvalid"),
     addedLabel: t("overlay.added"),
     removedLabel: t("overlay.removed"),
     totalLabel: t("base.optional"),

--- a/apps/portal/src/app/api/orchestration/webhook/route.test.ts
+++ b/apps/portal/src/app/api/orchestration/webhook/route.test.ts
@@ -1,0 +1,144 @@
+import { createHmac } from "node:crypto";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import Module from "node:module";
+import { pathToFileURL } from "node:url";
+import assert from "node:assert/strict";
+import test from "node:test";
+
+async function withRoute<T>(callback: (route: typeof import("./route")) => Promise<T>) {
+  const tempRoot = mkdtempSync(join(tmpdir(), "webhook-route-stub-"));
+  const scopeRoot = join(tempRoot, "@airnub");
+  const orchestratorRoot = join(scopeRoot, "orchestrator-temporal");
+  const utilsRoot = join(scopeRoot, "utils");
+  const previousNodePath = process.env.NODE_PATH;
+  try {
+    mkdirSync(orchestratorRoot, { recursive: true });
+    mkdirSync(utilsRoot, { recursive: true });
+
+    const orchestratorPackage = {
+      name: "@airnub/orchestrator-temporal",
+      type: "module",
+      exports: "./index.js"
+    } as const;
+    writeFileSync(join(orchestratorRoot, "package.json"), JSON.stringify(orchestratorPackage));
+    writeFileSync(join(orchestratorRoot, "index.js"), 'export class SecretAliasResolutionError extends Error {\n  constructor(alias, tenantId) {\n    super(`Unable to resolve secret alias "${alias}" for tenant "${tenantId}".`);\n    this.name = "SecretAliasResolutionError";\n  }\n}\n\nfunction sanitize(value) {\n  return value.trim().replace(/[^a-zA-Z0-9]/g, "_").replace(/_{2,}/g, "_").toUpperCase();\n}\n\nexport function resolveSecretAlias(tenantId, alias) {\n  if (!tenantId || !alias) {\n    throw new SecretAliasResolutionError(alias, tenantId);\n  }\n  const tenantKey = sanitize(tenantId);\n  const aliasKey = sanitize(alias);\n  const candidates = [\n    `FC_SECRET_${tenantKey}__${aliasKey}`,\n    `FC_SECRET__${aliasKey}`,\n    `SECRET_${tenantKey}__${aliasKey}`,\n    `SECRET__${aliasKey}`\n  ];\n  for (const key of candidates) {\n    const value = process.env[key];\n    if (typeof value === "string" && value.length > 0) {\n      return value;\n    }\n  }\n  throw new SecretAliasResolutionError(alias, tenantId);\n}');
+
+    const utilsPackage = {
+      name: "@airnub/utils",
+      type: "module",
+      exports: { "./telemetry": "./telemetry.js" }
+    } as const;
+    writeFileSync(join(utilsRoot, "package.json"), JSON.stringify(utilsPackage));
+    writeFileSync(join(utilsRoot, "telemetry.js"), 'export function annotateSpan() {}\n\nexport function setHttpAttributes() {}\n\nexport function extractRunMetadataFromHeaders(headers) {\n  if (!headers) {\n    return {};\n  }\n  const get = (name) => {\n    if (headers instanceof Headers) {\n      return headers.get(name) ?? undefined;\n    }\n    return headers[name] ?? undefined;\n  };\n  const runId = get("x-fc-run-id") ?? get("x-run-id") ?? get("x-temporal-run-id");\n  const stepId = get("x-fc-step-key") ?? get("x-step-id") ?? get("x-temporal-step-id");\n  return { runId: runId ?? undefined, stepId: stepId ?? undefined };\n}\n\nexport async function withTelemetrySpan(_name, _options, handler) {\n  const span = {\n    setAttribute() {},\n    recordException() {},\n    setStatus() {},\n    addEvent() {}\n  };\n  return await handler(span);\n}');
+
+    process.env.NODE_PATH = tempRoot + (previousNodePath ? `${delimiter}${previousNodePath}` : "");
+    Module._initPaths();
+    const route = await import("./route");
+    return await callback(route);
+  } finally {
+    process.env.NODE_PATH = previousNodePath;
+    Module._initPaths();
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+
+test("POST resolves secret aliases and forwards webhook requests", async () => {
+  await withRoute(async ({ POST }) => {
+    const baseAlias = "tests.webhooks.base";
+    const tokenAlias = "tests.webhooks.token";
+    const signingAlias = "tests.webhooks.signature";
+    process.env.FC_SECRET__TESTS_WEBHOOKS_BASE = "https://tenant.example.com";
+    process.env.FC_SECRET__TESTS_WEBHOOKS_TOKEN = "token-value";
+    process.env.FC_SECRET__TESTS_WEBHOOKS_SIGNATURE = "signing-secret";
+
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const originalFetch = global.fetch;
+    global.fetch = (async (
+      input: Parameters<typeof fetch>[0],
+      init?: Parameters<typeof fetch>[1]
+    ) => {
+      calls.push({ url: input instanceof URL ? input.toString() : String(input), init: init ?? {} });
+      return new Response("{\"ok\":true}", {
+        status: 200,
+        headers: { "content-type": "application/json" }
+      });
+    }) as typeof global.fetch;
+
+    try {
+      const payload = {
+        tenantId: "tenant-x",
+        orgId: "tenant-x",
+        runId: "run-123",
+        stepKey: "step-1",
+        request: {
+          method: "POST",
+          urlAlias: baseAlias,
+          tokenAlias,
+          path: "/integrations/fresh-comply",
+          headers: { "X-Custom": "value" },
+          body: { hello: "world" },
+          signing: { algo: "hmac-sha256" as const, secretAlias: signingAlias }
+        }
+      };
+
+      const response = await POST(
+        new Request("http://localhost/api/orchestration/webhook", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload)
+        })
+      );
+
+      assert.equal(response.status, 200);
+      const json = (await response.json()) as Record<string, unknown>;
+      assert.equal(json.ok, true);
+      assert.equal(calls.length, 1);
+
+      const forwarded = calls[0]!;
+      assert.equal(forwarded.url, "https://tenant.example.com/integrations/fresh-comply");
+      const headers = forwarded.init.headers instanceof Headers
+        ? forwarded.init.headers
+        : new Headers(forwarded.init.headers);
+      assert.equal(headers.get("authorization"), "Bearer token-value");
+      assert.equal(headers.get("x-custom"), "value");
+      assert.ok(headers.get("x-fc-idempotency-key"));
+
+      const expectedSignature = createHmac("sha256", "signing-secret")
+        .update(JSON.stringify(payload.request.body))
+        .digest("hex");
+      assert.equal(headers.get("x-fc-signature"), expectedSignature);
+    } finally {
+      global.fetch = originalFetch;
+      delete process.env.FC_SECRET__TESTS_WEBHOOKS_BASE;
+      delete process.env.FC_SECRET__TESTS_WEBHOOKS_TOKEN;
+      delete process.env.FC_SECRET__TESTS_WEBHOOKS_SIGNATURE;
+    }
+  });
+});
+
+test("POST rejects webhook configs with literal URLs", async () => {
+  await withRoute(async ({ POST }) => {
+    const payload = {
+      tenantId: "tenant-x",
+      request: {
+        method: "POST",
+        urlAlias: "https://example.com/webhook"
+      }
+    };
+
+    const response = await POST(
+      new Request("http://localhost/api/orchestration/webhook", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      })
+    );
+
+    assert.equal(response.status, 400);
+    const json = (await response.json()) as Record<string, unknown>;
+    assert.equal(json.ok, false);
+  });
+});

--- a/apps/portal/src/app/api/orchestration/webhook/route.ts
+++ b/apps/portal/src/app/api/orchestration/webhook/route.ts
@@ -1,0 +1,251 @@
+import { createHash, createHmac } from "node:crypto";
+import {
+  resolveSecretAlias,
+  SecretAliasResolutionError
+} from "@airnub/orchestrator-temporal";
+import {
+  annotateSpan,
+  extractRunMetadataFromHeaders,
+  setHttpAttributes,
+  withTelemetrySpan
+} from "@airnub/utils/telemetry";
+
+function jsonResponse(body: Record<string, unknown>, init?: ResponseInit) {
+  const headers = new Headers(init?.headers);
+  if (!headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers
+  });
+}
+
+const ROUTE = "/api/orchestration/webhook";
+const HTTP_METHODS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE"] as const);
+
+type HttpMethod = typeof HTTP_METHODS extends Set<infer T> ? T : never;
+
+type WebhookConfig = {
+  method: HttpMethod;
+  urlAlias: string;
+  tokenAlias?: string;
+  path?: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+  signing?: { algo: "hmac-sha256"; secretAlias: string };
+};
+
+function isMethod(value: unknown): value is HttpMethod {
+  return typeof value === "string" && HTTP_METHODS.has(value as never);
+}
+
+function isAlias(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0 && !value.includes("://");
+}
+
+function buildUrl(baseUrl: string, path?: string): string {
+  if (!path) {
+    return baseUrl;
+  }
+  const base = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+  const trimmedPath = path.startsWith("/") ? path.slice(1) : path;
+  return new URL(trimmedPath, base).toString();
+}
+
+function hashPayload(payload?: string): string {
+  const hash = createHash("sha256");
+  hash.update(payload ?? "");
+  return hash.digest("hex");
+}
+
+export async function POST(request: Request) {
+  const headerMetadata = extractRunMetadataFromHeaders(request.headers);
+
+  return withTelemetrySpan(`POST ${ROUTE}`, {
+    runId: headerMetadata.runId,
+    stepId: headerMetadata.stepId,
+    attributes: {
+      "http.request.method": "POST",
+      "http.route": ROUTE
+    }
+  }, async (span) => {
+    let payload: unknown;
+    try {
+      payload = await request.json();
+    } catch (error) {
+      const response = jsonResponse({ ok: false, error: "Invalid JSON body" }, { status: 400 });
+      setHttpAttributes(span, { method: "POST", route: ROUTE, status: response.status });
+      return response;
+    }
+
+    if (!payload || typeof payload !== "object") {
+      const response = jsonResponse({ ok: false, error: "Body must be an object" }, { status: 400 });
+      setHttpAttributes(span, { method: "POST", route: ROUTE, status: response.status });
+      return response;
+    }
+
+    const { tenantId, runId, stepKey, orgId, request: webhookRequest } = payload as Record<string, unknown>;
+
+    if (typeof tenantId !== "string" || tenantId.length === 0) {
+      const response = jsonResponse({ ok: false, error: "tenantId is required" }, { status: 400 });
+      setHttpAttributes(span, { method: "POST", route: ROUTE, status: response.status });
+      return response;
+    }
+
+    if (!webhookRequest || typeof webhookRequest !== "object") {
+      const response = jsonResponse({ ok: false, error: "request config is required" }, { status: 400 });
+      setHttpAttributes(span, { method: "POST", route: ROUTE, status: response.status });
+      return response;
+    }
+
+    const { method, urlAlias, tokenAlias, path: requestPath, headers, body, signing } =
+      webhookRequest as WebhookConfig;
+
+    if (!isMethod(method)) {
+      const response = jsonResponse({ ok: false, error: "Unsupported HTTP method" }, { status: 400 });
+      setHttpAttributes(span, { method: "POST", route: ROUTE, status: response.status });
+      return response;
+    }
+
+    if (!isAlias(urlAlias)) {
+      const response = jsonResponse({ ok: false, error: "urlAlias must reference a secret alias" }, { status: 400 });
+      setHttpAttributes(span, { method: "POST", route: ROUTE, status: response.status });
+      return response;
+    }
+
+    if (tokenAlias && !isAlias(tokenAlias)) {
+      const response = jsonResponse({ ok: false, error: "tokenAlias must reference a secret alias" }, { status: 400 });
+      setHttpAttributes(span, { method: "POST", route: ROUTE, status: response.status });
+      return response;
+    }
+
+    if (signing && signing.algo !== "hmac-sha256") {
+      const response = jsonResponse({ ok: false, error: "Unsupported signing algorithm" }, { status: 400 });
+      setHttpAttributes(span, { method: "POST", route: ROUTE, status: response.status });
+      return response;
+    }
+
+    if (signing && !isAlias(signing.secretAlias)) {
+      const response = jsonResponse({ ok: false, error: "signing.secretAlias must reference a secret alias" }, { status: 400 });
+      setHttpAttributes(span, { method: "POST", route: ROUTE, status: response.status });
+      return response;
+    }
+
+    annotateSpan(span, {
+      runId: typeof runId === "string" ? runId : undefined,
+      stepId: typeof stepKey === "string" ? stepKey : undefined,
+      orgId: typeof orgId === "string" ? orgId : tenantId,
+      attributes: {
+        "freshcomply.webhook.url_alias": urlAlias
+      }
+    });
+
+    let baseUrl: string;
+    let token: string | undefined;
+    let signingSecret: string | undefined;
+    try {
+      baseUrl = resolveSecretAlias(tenantId, urlAlias);
+      token = tokenAlias ? resolveSecretAlias(tenantId, tokenAlias) : undefined;
+      signingSecret = signing ? resolveSecretAlias(tenantId, signing.secretAlias) : undefined;
+    } catch (error) {
+      if (error instanceof SecretAliasResolutionError) {
+        const response = jsonResponse({ ok: false, error: "Unable to resolve secret alias" }, { status: 503 });
+        setHttpAttributes(span, { method: "POST", route: ROUTE, status: response.status });
+        return response;
+      }
+      const response = jsonResponse({ ok: false, error: "Unexpected error resolving aliases" }, { status: 500 });
+      setHttpAttributes(span, { method: "POST", route: ROUTE, status: response.status });
+      return response;
+    }
+
+    const url = buildUrl(baseUrl, requestPath);
+    const requestHeaders = new Headers();
+    requestHeaders.set("User-Agent", "fresh-comply-portal/1.0");
+    const idempotencyKey = `${tenantId}:${runId ?? ""}:${stepKey ?? ""}:${Date.now()}`;
+    requestHeaders.set("X-FC-Idempotency-Key", idempotencyKey);
+    if (typeof runId === "string") {
+      requestHeaders.set("X-FC-Run-Id", runId);
+    }
+    if (typeof stepKey === "string") {
+      requestHeaders.set("X-FC-Step-Key", stepKey);
+    }
+
+    if (headers) {
+      for (const [key, value] of Object.entries(headers)) {
+        requestHeaders.set(key, value);
+      }
+    }
+
+    let bodyString: string | undefined;
+    if (body !== undefined && body !== null) {
+      bodyString = typeof body === "string" ? body : JSON.stringify(body);
+      if (!requestHeaders.has("Content-Type")) {
+        requestHeaders.set("Content-Type", "application/json");
+      }
+    }
+
+    if (token) {
+      requestHeaders.set("Authorization", `Bearer ${token}`);
+    }
+
+    if (signingSecret && bodyString) {
+      const signature = createHmac("sha256", signingSecret).update(bodyString).digest("hex");
+      requestHeaders.set("X-FC-Signature", signature);
+    }
+
+    let response: globalThis.Response;
+    try {
+      response = await fetch(url, {
+        method,
+        headers: requestHeaders,
+        body: bodyString
+      });
+    } catch (error) {
+      console.error("[webhook] Failed to invoke endpoint", error);
+      const failure = jsonResponse({ ok: false, error: "Failed to invoke webhook" }, { status: 502 });
+      setHttpAttributes(span, { method: "POST", route: ROUTE, status: failure.status });
+      return failure;
+    }
+
+    const responseHeaders: Record<string, string> = {};
+    response.headers.forEach((value, key) => {
+      responseHeaders[key.toLowerCase()] = value;
+    });
+    const bodyText = await response.text();
+    const responseHash = hashPayload(bodyText);
+
+    annotateSpan(span, {
+      attributes: {
+        "http.response.status_code": response.status,
+        "freshcomply.http.url": url,
+        "freshcomply.http.response_hash": responseHash
+      }
+    });
+
+    if (!response.ok) {
+      const failure = jsonResponse(
+        {
+          ok: false,
+          error: `Webhook request failed with status ${response.status}`,
+          status: response.status,
+          responseHash
+        },
+        { status: 502 }
+      );
+      setHttpAttributes(span, { method: "POST", route: ROUTE, status: failure.status });
+      return failure;
+    }
+
+    const success = jsonResponse({
+      ok: true,
+      status: response.status,
+      requestHash: hashPayload(bodyString),
+      responseHash,
+      headers: responseHeaders,
+      bodyPreview: bodyText.slice(0, 512)
+    });
+    setHttpAttributes(span, { method: "POST", route: ROUTE, status: success.status });
+    return success;
+  });
+}

--- a/apps/portal/src/components/__tests__/tenant-overlay-builder.test.ts
+++ b/apps/portal/src/components/__tests__/tenant-overlay-builder.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {
+  TemporalStepExecution,
+  WebhookStepExecution,
+  WebsocketStepExecution
+} from "@airnub/engine/types";
+import {
+  normaliseExecution,
+  sanitizeTemporalExecution,
+  sanitizeWebhookExecution,
+  sanitizeWebsocketExecution
+} from "../tenant-overlay-execution";
+
+test("normaliseExecution merges temporal config fields", () => {
+  const legacy: TemporalStepExecution = {
+    mode: "temporal",
+    config: { workflow: "legacyWorkflow", taskQueue: "legacyQueue" }
+  };
+
+  const normalised = normaliseExecution(legacy) as TemporalStepExecution;
+  assert.equal(normalised.mode, "temporal");
+  assert.equal(normalised.workflow, "legacyWorkflow");
+  assert.equal(normalised.taskQueue, "legacyQueue");
+  assert.equal(normalised.config?.workflow, "legacyWorkflow");
+  assert.equal(normalised.config?.taskQueue, "legacyQueue");
+});
+
+test("sanitizeTemporalExecution drops empty overrides", () => {
+  const execution: TemporalStepExecution = {
+    mode: "temporal",
+    workflow: "  workflow-name  ",
+    taskQueue: "   ",
+    defaultTaskQueue: " default-queue "
+  };
+
+  const sanitized = sanitizeTemporalExecution(execution);
+  assert.equal(sanitized.workflow, "workflow-name");
+  assert.ok(!("taskQueue" in sanitized));
+  assert.equal(sanitized.defaultTaskQueue, "default-queue");
+  assert.equal(sanitized.config?.defaultTaskQueue, "default-queue");
+});
+
+test("sanitizeWebhookExecution trims aliases and omits blanks", () => {
+  const execution: WebhookStepExecution = {
+    mode: "external:webhook",
+    config: {
+      method: "POST",
+      urlAlias: " webhook.base ",
+      tokenAlias: "  webhook.token  ",
+      path: " /callback ",
+      headers: { "X-Test": "true" },
+      signing: { algo: "hmac-sha256", secretAlias: " signature " }
+    }
+  };
+
+  const sanitized = sanitizeWebhookExecution(execution);
+  assert.equal(sanitized.config.urlAlias, "webhook.base");
+  assert.equal(sanitized.config.tokenAlias, "webhook.token");
+  assert.equal(sanitized.config.path, "/callback");
+  assert.ok(sanitized.config.signing);
+  assert.equal(sanitized.config.signing?.secretAlias, "signature");
+
+  const withoutSigning: WebhookStepExecution = {
+    mode: "external:webhook",
+    config: {
+      method: "POST",
+      urlAlias: " webhook.base ",
+      signing: { algo: "hmac-sha256", secretAlias: "   " }
+    }
+  };
+
+  const sanitizedNoSigning = sanitizeWebhookExecution(withoutSigning);
+  assert.ok(!sanitizedNoSigning.config.signing);
+});
+
+test("sanitizeWebsocketExecution retains provided overrides", () => {
+  const execution: WebsocketStepExecution = {
+    mode: "external:websocket",
+    config: {
+      urlAlias: " websocket.base ",
+      tokenAlias: "  websocket.token  ",
+      messageSchema: " schema.json ",
+      temporalWorkflow: " externalJobWorkflow ",
+      defaultTaskQueue: "  tenant-queue  ",
+      taskQueueOverride: "  override-queue  "
+    }
+  };
+
+  const sanitized = sanitizeWebsocketExecution(execution);
+  assert.equal(sanitized.config.urlAlias, "websocket.base");
+  assert.equal(sanitized.config.tokenAlias, "websocket.token");
+  assert.equal(sanitized.config.messageSchema, "schema.json");
+  assert.equal(sanitized.config.temporalWorkflow, "externalJobWorkflow");
+  assert.equal(sanitized.config.defaultTaskQueue, "tenant-queue");
+  assert.equal(sanitized.config.taskQueueOverride, "override-queue");
+});

--- a/apps/portal/src/components/tenant-overlay-execution.ts
+++ b/apps/portal/src/components/tenant-overlay-execution.ts
@@ -1,0 +1,145 @@
+import type {
+  StepExecution,
+  TemporalStepExecution,
+  WebhookStepExecution,
+  WebsocketStepExecution
+} from "@airnub/engine/types";
+
+type ExecutionAliasKey = "urlAlias" | "tokenAlias" | "signing.secretAlias";
+
+function isTemporalExecution(execution: StepExecution): execution is TemporalStepExecution {
+  return execution.mode === "temporal";
+}
+
+function isWebhookExecution(execution: StepExecution): execution is WebhookStepExecution {
+  return execution.mode === "external:webhook";
+}
+
+function isWebsocketExecution(execution: StepExecution): execution is WebsocketStepExecution {
+  return execution.mode === "external:websocket";
+}
+
+function normaliseExecution(execution: StepExecution): StepExecution {
+  switch (execution.mode) {
+    case "temporal": {
+      const workflow = execution.workflow ?? execution.config?.workflow ?? "";
+      const taskQueue = execution.taskQueue ?? execution.config?.taskQueue ?? "";
+      const defaultTaskQueue = execution.defaultTaskQueue ?? execution.config?.defaultTaskQueue ?? "";
+      return {
+        mode: "temporal",
+        workflow,
+        taskQueue,
+        defaultTaskQueue,
+        config: {
+          workflow,
+          taskQueue,
+          defaultTaskQueue
+        }
+      } satisfies TemporalStepExecution;
+    }
+    case "external:webhook": {
+      return {
+        mode: "external:webhook",
+        config: {
+          method: execution.config?.method ?? "POST",
+          urlAlias: execution.config?.urlAlias ?? "",
+          tokenAlias: execution.config?.tokenAlias ?? "",
+          path: execution.config?.path ?? "",
+          headers: execution.config?.headers ? { ...execution.config.headers } : undefined,
+          signing: execution.config?.signing
+            ? { ...execution.config.signing }
+            : undefined
+        }
+      } satisfies WebhookStepExecution;
+    }
+    case "external:websocket": {
+      return {
+        mode: "external:websocket",
+        config: {
+          urlAlias: execution.config?.urlAlias ?? "",
+          tokenAlias: execution.config?.tokenAlias ?? "",
+          messageSchema: execution.config?.messageSchema ?? "",
+          temporalWorkflow: execution.config?.temporalWorkflow ?? "",
+          defaultTaskQueue: execution.config?.defaultTaskQueue ?? "",
+          taskQueueOverride: execution.config?.taskQueueOverride ?? ""
+        }
+      } satisfies WebsocketStepExecution;
+    }
+    default:
+      return { mode: "manual" };
+  }
+}
+
+function sanitizeTemporalExecution(execution: TemporalStepExecution): TemporalStepExecution {
+  const workflow = execution.workflow?.trim() ?? "";
+  const taskQueue = execution.taskQueue?.trim() ?? "";
+  const defaultTaskQueue = execution.defaultTaskQueue?.trim() ?? "";
+  const configEntries = [
+    ["workflow", workflow],
+    ["taskQueue", taskQueue],
+    ["defaultTaskQueue", defaultTaskQueue]
+  ] as const;
+  const config = Object.fromEntries(
+    configEntries.filter(([, value]) => value.length > 0)
+  ) as TemporalStepExecution["config"];
+
+  const sanitized: TemporalStepExecution = { mode: "temporal" };
+  if (workflow) sanitized.workflow = workflow;
+  if (taskQueue) sanitized.taskQueue = taskQueue;
+  if (defaultTaskQueue) sanitized.defaultTaskQueue = defaultTaskQueue;
+  if (config && Object.keys(config).length > 0) sanitized.config = config;
+  return sanitized;
+}
+
+function sanitizeWebhookExecution(execution: WebhookStepExecution): WebhookStepExecution {
+  const urlAlias = execution.config.urlAlias.trim();
+  const tokenAlias = execution.config.tokenAlias?.trim();
+  const path = execution.config.path?.trim();
+  const signingAlias = execution.config.signing?.secretAlias?.trim();
+  const signing =
+    signingAlias && signingAlias.length > 0
+      ? { algo: "hmac-sha256" as const, secretAlias: signingAlias }
+      : undefined;
+
+  const config: WebhookStepExecution["config"] = {
+    method: execution.config.method,
+    urlAlias,
+    ...(tokenAlias ? { tokenAlias } : {}),
+    ...(path ? { path } : {}),
+    ...(execution.config.headers ? { headers: execution.config.headers } : {}),
+    ...(signing ? { signing } : {})
+  };
+
+  return { mode: "external:webhook", config };
+}
+
+function sanitizeWebsocketExecution(execution: WebsocketStepExecution): WebsocketStepExecution {
+  const urlAlias = execution.config.urlAlias.trim();
+  const tokenAlias = execution.config.tokenAlias?.trim();
+  const messageSchema = execution.config.messageSchema?.trim();
+  const temporalWorkflow = execution.config.temporalWorkflow?.trim();
+  const defaultTaskQueue = execution.config.defaultTaskQueue?.trim();
+  const taskQueueOverride = execution.config.taskQueueOverride?.trim();
+
+  const config: WebsocketStepExecution["config"] = {
+    urlAlias,
+    ...(tokenAlias ? { tokenAlias } : {}),
+    ...(messageSchema ? { messageSchema } : {}),
+    ...(temporalWorkflow ? { temporalWorkflow } : {}),
+    ...(defaultTaskQueue ? { defaultTaskQueue } : {}),
+    ...(taskQueueOverride ? { taskQueueOverride } : {})
+  };
+
+  return { mode: "external:websocket", config };
+}
+
+export {
+  ExecutionAliasKey,
+  isTemporalExecution,
+  isWebhookExecution,
+  isWebsocketExecution,
+  normaliseExecution,
+  sanitizeTemporalExecution,
+  sanitizeWebhookExecution,
+  sanitizeWebsocketExecution
+};

--- a/apps/portal/src/lib/demo-data.ts
+++ b/apps/portal/src/lib/demo-data.ts
@@ -66,20 +66,27 @@ export async function getDemoRun(): Promise<DemoRun> {
     materializeSteps(dsl).map(async (step, index) => {
       const execution = step.execution as StepExecution | undefined;
       const orchestration =
-        execution?.mode === "temporal"
+        execution?.mode === "temporal" || execution?.mode === "external:websocket"
           ? {
               status: orchestrationStates[index] ?? "idle",
-            workflowId: `demo-${step.id}`,
-            resultSummary:
-              index === 0
-                ? "Name available — reserved for 28 days"
-                : index === 1
-                  ? "Rendering board minutes and filings"
-                  : index === 3
-                    ? "Awaiting advisor confirmation"
-                    : undefined
-          }
-        : undefined;
+              workflowId: `demo-${step.id}`,
+              resultSummary:
+                index === 0
+                  ? "Name available — reserved for 28 days"
+                  : index === 1
+                    ? "Rendering board minutes and filings"
+                    : index === 3
+                      ? "Awaiting advisor confirmation"
+                      : execution?.mode === "external:websocket"
+                        ? "Listening for tenant stream events"
+                        : undefined
+            }
+          : execution?.mode === "external:webhook"
+            ? {
+                status: "idle" as const,
+                resultSummary: "Invoke tenant webhook with signed payload"
+              }
+            : undefined;
 
     const status: DemoStep["status"] =
       index === 0

--- a/packages/engine/src/__tests__/execution.test.ts
+++ b/packages/engine/src/__tests__/execution.test.ts
@@ -1,0 +1,133 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { Operation } from "fast-json-patch";
+import { loadDSL } from "../dsl.js";
+import { materializeWorkflow } from "../engine.js";
+import type { StepDef, WorkflowDSL } from "../types.js";
+
+test("loadDSL preserves external execution metadata", () => {
+  const dir = mkdtempSync(join(tmpdir(), "fc-dsl-"));
+  const filePath = join(dir, "workflow.yaml");
+  const yaml = `id: demo-workflow\nversion: 1.0.0\ntitle: Demo\nsteps:\n  - id: webhook-step\n    kind: action\n    title: Demo webhook\n    execution:\n      mode: external:webhook\n      config:\n        method: POST\n        urlAlias: secrets.webhook.base\n        tokenAlias: secrets.webhook.token\n  - id: websocket-step\n    kind: tool.call\n    title: Demo websocket\n    execution:\n      mode: external:websocket\n      config:\n        urlAlias: secrets.websocket.base\n        temporalWorkflow: externalJobWorkflow\n`;
+  writeFileSync(filePath, yaml, "utf8");
+
+  const workflow = loadDSL(filePath);
+  const webhook = workflow.steps[0]?.execution;
+  const websocket = workflow.steps[1]?.execution;
+
+  assert.equal(webhook?.mode, "external:webhook");
+  assert.equal(websocket?.mode, "external:websocket");
+});
+
+test("materializeWorkflow validates webhook execution aliases", () => {
+  const workflow: WorkflowDSL = {
+    id: "wf-alias",
+    version: "1",
+    steps: [
+      {
+        id: "external-webhook",
+        kind: "action",
+        title: "Webhook",
+        execution: {
+          mode: "external:webhook",
+          config: {
+            method: "POST",
+            urlAlias: "secrets.webhook.base",
+            tokenAlias: "secrets.webhook.token"
+          }
+        }
+      } satisfies StepDef
+    ]
+  };
+
+  const result = materializeWorkflow(workflow);
+  assert.equal(result.steps[0]?.execution?.mode, "external:webhook");
+
+  const invalid: WorkflowDSL = {
+    ...workflow,
+    steps: [
+      {
+        ...workflow.steps[0]!,
+        execution: {
+          mode: "external:webhook",
+          config: {
+            method: "POST",
+            urlAlias: "https://example.com/webhook"
+          }
+        }
+      } satisfies StepDef
+    ]
+  };
+
+  assert.throws(
+    () => materializeWorkflow(invalid),
+    /must reference a urlAlias secret/
+  );
+
+  const literalToken: WorkflowDSL = {
+    ...workflow,
+    steps: [
+      {
+        ...workflow.steps[0]!,
+        execution: {
+          mode: "external:webhook",
+          config: {
+            method: "POST",
+            urlAlias: "secrets.webhook.base",
+            // @ts-expect-error intentional invalid config for validation
+            token: "literal"
+          }
+        }
+      } satisfies StepDef
+    ]
+  };
+
+  assert.throws(
+    () => materializeWorkflow(literalToken),
+    /must not include a raw token/
+  );
+});
+
+test("materializeWorkflow merges overlays with external websocket execution", () => {
+  const workflow: WorkflowDSL = {
+    id: "wf-overlay",
+    version: "1",
+    steps: [
+      {
+        id: "base-step",
+        kind: "info",
+        title: "Base"
+      } satisfies StepDef
+    ]
+  };
+
+  const overlayOperations: Operation[] = [
+    {
+      op: "add",
+      path: "/steps/-",
+      value: {
+        id: "websocket-step",
+        kind: "tool.call",
+        title: "External stream",
+        execution: {
+          mode: "external:websocket",
+          config: {
+            urlAlias: "secrets.websocket.base",
+            temporalWorkflow: "externalJobWorkflow"
+          }
+        }
+      }
+    }
+  ];
+
+  const materialized = materializeWorkflow(workflow, {
+    overlays: [{ operations: overlayOperations }]
+  });
+
+  const websocketStep = materialized.steps.find((step) => step.id === "websocket-step");
+  assert.ok(websocketStep, "websocket step should be present after overlay merge");
+  assert.equal(websocketStep?.execution?.mode, "external:websocket");
+});

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -1,11 +1,61 @@
 export type NodeKind = "question" | "info" | "action" | "upload" | "doc.generate" | "tool.call" | "verify" | "schedule" | "review";
 export type RuleRef = { id: string };
-export type StepExecution = {
-  mode: "manual" | "temporal";
+export type ManualStepExecution = {
+  mode: "manual";
+};
+
+export type TemporalExecutionConfig = {
   workflow?: string;
   taskQueue?: string;
-  config?: Record<string, unknown>;
+  defaultTaskQueue?: string;
 };
+
+export type TemporalStepExecution = {
+  mode: "temporal";
+  workflow?: string;
+  taskQueue?: string;
+  defaultTaskQueue?: string;
+  config?: TemporalExecutionConfig;
+};
+
+export type WebhookSigningConfig = {
+  algo: "hmac-sha256";
+  secretAlias: string;
+};
+
+export type WebhookExecutionConfig = {
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  urlAlias: string;
+  tokenAlias?: string;
+  path?: string;
+  headers?: Record<string, string>;
+  signing?: WebhookSigningConfig;
+};
+
+export type WebhookStepExecution = {
+  mode: "external:webhook";
+  config: WebhookExecutionConfig;
+};
+
+export type WebsocketExecutionConfig = {
+  urlAlias: string;
+  tokenAlias?: string;
+  messageSchema?: string;
+  temporalWorkflow?: string;
+  defaultTaskQueue?: string;
+  taskQueueOverride?: string;
+};
+
+export type WebsocketStepExecution = {
+  mode: "external:websocket";
+  config: WebsocketExecutionConfig;
+};
+
+export type StepExecution =
+  | ManualStepExecution
+  | TemporalStepExecution
+  | WebhookStepExecution
+  | WebsocketStepExecution;
 
 export type StepSecretBinding = {
   alias: string;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -27,7 +27,9 @@ export const Step = z.object({
   title: z.string(),
   status: z.enum(["todo", "in_progress", "waiting", "blocked", "done"]),
   orchestrationRunId: z.string().optional(),
-  executionMode: z.enum(["manual", "temporal"]).optional(),
+  executionMode: z
+    .enum(["manual", "temporal", "external:webhook", "external:websocket"])
+    .optional(),
   dueDate: z.string().datetime().optional(),
   assigneeUserId: Id.optional(),
   stepTypeVersionId: Id.optional(),

--- a/packages/types/src/supabase.ts
+++ b/packages/types/src/supabase.ts
@@ -356,7 +356,7 @@ export type Database = {
           title: string;
           status: "todo" | "in_progress" | "waiting" | "blocked" | "done";
           orchestration_run_id: string | null;
-          execution_mode: "manual" | "temporal";
+          execution_mode: "manual" | "temporal" | "external:webhook" | "external:websocket";
           due_date: string | null;
           assignee_user_id: string | null;
           step_type_version_id: string | null;
@@ -369,7 +369,7 @@ export type Database = {
           title: string;
           status?: "todo" | "in_progress" | "waiting" | "blocked" | "done";
           orchestration_run_id?: string | null;
-          execution_mode?: "manual" | "temporal";
+          execution_mode?: "manual" | "temporal" | "external:webhook" | "external:websocket";
           due_date?: string | null;
           assignee_user_id?: string | null;
           step_type_version_id?: string | null;
@@ -382,7 +382,7 @@ export type Database = {
           title?: string;
           status?: "todo" | "in_progress" | "waiting" | "blocked" | "done";
           orchestration_run_id?: string | null;
-          execution_mode?: "manual" | "temporal";
+          execution_mode?: "manual" | "temporal" | "external:webhook" | "external:websocket";
           due_date?: string | null;
           assignee_user_id?: string | null;
           step_type_version_id?: string | null;

--- a/packages/ui/src/TaskBoard.tsx
+++ b/packages/ui/src/TaskBoard.tsx
@@ -1,13 +1,30 @@
 import React from "react";
 import { Badge, Card, Flex, Grid, Text, type BadgeProps } from "@radix-ui/themes";
 
+type ExecutionMode = "manual" | "temporal" | "external:webhook" | "external:websocket";
+
+function formatExecutionLabel(mode: ExecutionMode, orchestrationStatus?: string) {
+  switch (mode) {
+    case "temporal":
+      return orchestrationStatus ? `Temporal · ${orchestrationStatus.replace(/_/g, " ")}` : "Temporal";
+    case "external:webhook":
+      return "External · Webhook";
+    case "external:websocket":
+      return orchestrationStatus
+        ? `External · WebSocket · ${orchestrationStatus.replace(/_/g, " ")}`
+        : "External · WebSocket";
+    default:
+      return "Manual";
+  }
+}
+
 export type Task = {
   id: string;
   title: string;
   status: "todo" | "in_progress" | "waiting" | "blocked" | "done";
   assignee?: string;
   dueDate?: string;
-  executionMode?: "manual" | "temporal";
+  executionMode?: ExecutionMode;
   orchestrationStatus?: string;
 };
 
@@ -68,15 +85,19 @@ export function TaskBoard({ tasks, statusLabels, formatDueDate }: TaskBoardProps
                             )}
                             {task.executionMode && (
                               <Badge
-                                color={task.executionMode === "temporal" ? "blue" : "gray"}
+                                color={
+                                  task.executionMode === "temporal"
+                                    ? "blue"
+                                    : task.executionMode === "external:webhook"
+                                      ? "amber"
+                                      : task.executionMode === "external:websocket"
+                                        ? "teal"
+                                        : "gray"
+                                }
                                 radius="full"
                                 variant="soft"
                               >
-                                {task.executionMode === "temporal"
-                                  ? task.orchestrationStatus
-                                    ? `Temporal · ${task.orchestrationStatus.replace(/_/g, " ")}`
-                                    : "Temporal"
-                                  : "Manual"}
+                                {formatExecutionLabel(task.executionMode, task.orchestrationStatus)}
                               </Badge>
                             )}
                           </Flex>


### PR DESCRIPTION
## Summary
- extend the engine StepExecution schema and validation to cover the new `external:webhook`/`external:websocket` modes and enforce alias-only metadata
- update the tenant overlay builder UI to configure alias-bound execution data and expose the orchestration webhook API at `apps/portal/src/app/api/orchestration/webhook/route.ts`
- add focused tests for the new behaviour in `packages/engine/src/__tests__/execution.test.ts`, `apps/portal/src/components/__tests__/tenant-overlay-builder.test.ts`, and `apps/portal/src/app/api/orchestration/webhook/route.test.ts`

## Testing
- pnpm exec tsx --test packages/engine/src/__tests__/execution.test.ts
- pnpm exec tsx --test apps/portal/src/components/__tests__/tenant-overlay-builder.test.ts
- pnpm exec tsx --test apps/portal/src/app/api/orchestration/webhook/route.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dfe849915c8324ad1888d3bf3541c4