### PR TITLE
Propagate tenant scoping through admin APIs

### DIFF
--- a/apps/admin/src/app/[locale]/dsr/actions.ts
+++ b/apps/admin/src/app/[locale]/dsr/actions.ts
@@ -44,7 +44,7 @@ function normalizeEmail(email: string) {
 async function loadRequest(client: ReturnType<typeof getSupabaseClient>, id: string) {
   const { data, error } = await client
     .from("dsr_requests")
-    .select("id, tenant_org_id, status, due_at")
+    .select("id, tenant_org_id, subject_org_id, status, due_at")
     .eq("id", id)
     .maybeSingle();
 
@@ -136,8 +136,12 @@ export async function reassignDsrRequest(id: string, email: string, reason: stri
 
     if (service) {
       await service.from("audit_log").insert({
+        tenant_org_id: request.tenant_org_id,
         actor_user_id: user?.id ?? null,
         actor_org_id: request.tenant_org_id,
+        on_behalf_of_org_id: request.subject_org_id ?? null,
+        subject_org_id: request.subject_org_id ?? null,
+        entity: "dsr_request",
         action: "dsr.request.reassigned",
         meta_json: {
           request_id: id,
@@ -189,8 +193,12 @@ export async function completeDsrRequest(id: string, reason: string): Promise<Ds
     const service = resolveServiceClient();
     if (service) {
       await service.from("audit_log").insert({
+        tenant_org_id: request.tenant_org_id,
         actor_user_id: user?.id ?? null,
         actor_org_id: request.tenant_org_id,
+        on_behalf_of_org_id: request.subject_org_id ?? null,
+        subject_org_id: request.subject_org_id ?? null,
+        entity: "dsr_request",
         action: "dsr.request.completed",
         meta_json: {
           request_id: id,
@@ -255,8 +263,12 @@ export async function togglePauseDsrRequest(id: string, reason: string): Promise
     const service = resolveServiceClient();
     if (service) {
       await service.from("audit_log").insert({
+        tenant_org_id: request.tenant_org_id,
         actor_user_id: user?.id ?? null,
         actor_org_id: request.tenant_org_id,
+        on_behalf_of_org_id: request.subject_org_id ?? null,
+        subject_org_id: request.subject_org_id ?? null,
+        entity: "dsr_request",
         action: nextStatus === "paused" ? "dsr.request.paused" : "dsr.request.resumed",
         meta_json: {
           request_id: id,

--- a/apps/admin/src/app/api/admin/__tests__/cancel-run.test.ts
+++ b/apps/admin/src/app/api/admin/__tests__/cancel-run.test.ts
@@ -27,6 +27,9 @@ describe("cancel run handler", () => {
       userId: "00000000-0000-0000-0000-000000000001",
       email: "actor@example.com",
       role: "platform_admin",
+      tenantOrgId: "10000000-0000-0000-0000-000000000000",
+      actorOrgId: "10000000-0000-0000-0000-000000000000",
+      onBehalfOfOrgId: null,
     });
   });
 
@@ -66,6 +69,9 @@ describe("cancel run handler", () => {
       run_id: "run-9",
       reason: "Need to stop",
       second_actor_id: "00000000-0000-0000-0000-000000000002",
+      tenant_org_id: "10000000-0000-0000-0000-000000000000",
+      actor_org_id: "10000000-0000-0000-0000-000000000000",
+      on_behalf_of_org_id: null,
     });
   });
 });

--- a/apps/admin/src/app/api/admin/dsr/[requestId]/acknowledge/route.ts
+++ b/apps/admin/src/app/api/admin/dsr/[requestId]/acknowledge/route.ts
@@ -18,12 +18,22 @@ export async function POST(request: Request, { params }: { params: { requestId: 
     return parsed;
   }
 
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return NextResponse.json({ error: "Tenant context unavailable" }, { status: 403 });
+  }
+
   try {
     const result = await callAdminRpc<Record<string, unknown>>("admin_acknowledge_dsr", {
       actor_id: context.userId,
       request_id: params.requestId,
       reason: parsed.reason,
       notes: parsed.notes ?? null,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,
     });
 
     return NextResponse.json({

--- a/apps/admin/src/app/api/admin/dsr/[requestId]/export/route.ts
+++ b/apps/admin/src/app/api/admin/dsr/[requestId]/export/route.ts
@@ -20,12 +20,22 @@ export async function POST(request: Request, { params }: { params: { requestId: 
     return parsed;
   }
 
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return NextResponse.json({ error: "Tenant context unavailable" }, { status: 403 });
+  }
+
   try {
     const result = await callAdminRpc<Record<string, unknown>>("admin_export_dsr_bundle", {
       actor_id: context.userId,
       request_id: params.requestId,
       reason: parsed.reason,
       destination: parsed.destination,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,
     });
 
     return NextResponse.json({

--- a/apps/admin/src/app/api/admin/dsr/[requestId]/legal-hold/route.ts
+++ b/apps/admin/src/app/api/admin/dsr/[requestId]/legal-hold/route.ts
@@ -31,6 +31,13 @@ export async function POST(request: Request, { params }: { params: { requestId: 
     return NextResponse.json({ error: "Second approver must be another admin" }, { status: 400 });
   }
 
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return NextResponse.json({ error: "Tenant context unavailable" }, { status: 403 });
+  }
+
   try {
     const result = await callAdminRpc<Record<string, unknown>>("admin_toggle_legal_hold", {
       actor_id: context.userId,
@@ -38,6 +45,9 @@ export async function POST(request: Request, { params }: { params: { requestId: 
       reason: parsed.reason,
       enabled: parsed.enabled,
       second_actor_id: secondActorId,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,
     });
 
     return NextResponse.json({

--- a/apps/admin/src/app/api/admin/dsr/[requestId]/resolve/route.ts
+++ b/apps/admin/src/app/api/admin/dsr/[requestId]/resolve/route.ts
@@ -18,12 +18,22 @@ export async function POST(request: Request, { params }: { params: { requestId: 
     return parsed;
   }
 
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return NextResponse.json({ error: "Tenant context unavailable" }, { status: 403 });
+  }
+
   try {
     const result = await callAdminRpc<Record<string, unknown>>("admin_resolve_dsr", {
       actor_id: context.userId,
       request_id: params.requestId,
       reason: parsed.reason,
       resolution: parsed.resolution,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,
     });
 
     return NextResponse.json({

--- a/apps/admin/src/app/api/admin/freshness/diffs/[diffId]/approve/route.ts
+++ b/apps/admin/src/app/api/admin/freshness/diffs/[diffId]/approve/route.ts
@@ -18,12 +18,22 @@ export async function POST(request: Request, { params }: { params: { diffId: str
     return parsed;
   }
 
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return NextResponse.json({ error: "Tenant context unavailable" }, { status: 403 });
+  }
+
   try {
     const result = await callAdminRpc<Record<string, unknown>>("admin_approve_freshness_diff", {
       actor_id: context.userId,
       diff_id: params.diffId,
       reason: parsed.reason,
       notes: parsed.notes ?? null,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,
     });
 
     return NextResponse.json({

--- a/apps/admin/src/app/api/admin/freshness/diffs/[diffId]/reject/route.ts
+++ b/apps/admin/src/app/api/admin/freshness/diffs/[diffId]/reject/route.ts
@@ -18,12 +18,22 @@ export async function POST(request: Request, { params }: { params: { diffId: str
     return parsed;
   }
 
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return NextResponse.json({ error: "Tenant context unavailable" }, { status: 403 });
+  }
+
   try {
     const result = await callAdminRpc<Record<string, unknown>>("admin_reject_freshness_diff", {
       actor_id: context.userId,
       diff_id: params.diffId,
       reason: parsed.reason,
       notes: parsed.notes ?? null,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,
     });
 
     return NextResponse.json({

--- a/apps/admin/src/app/api/admin/runs/[runId]/cancel/route.ts
+++ b/apps/admin/src/app/api/admin/runs/[runId]/cancel/route.ts
@@ -27,12 +27,22 @@ export async function POST(request: Request, { params }: { params: { runId: stri
     return NextResponse.json({ error: "Cancellation does not require second approval" }, { status: 400 });
   }
 
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return NextResponse.json({ error: "Tenant context unavailable" }, { status: 403 });
+  }
+
   try {
     const result = await callAdminRpc<Record<string, unknown>>("admin_cancel_run", {
       actor_id: context.userId,
       run_id: params.runId,
       reason: parsed.reason,
       second_actor_id: parsed.approvedBy,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,
     });
 
     return NextResponse.json({

--- a/apps/admin/src/app/api/admin/runs/[runId]/digest/resend/route.ts
+++ b/apps/admin/src/app/api/admin/runs/[runId]/digest/resend/route.ts
@@ -18,12 +18,22 @@ export async function POST(request: Request, { params }: { params: { runId: stri
     return parsed;
   }
 
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return NextResponse.json({ error: "Tenant context unavailable" }, { status: 403 });
+  }
+
   try {
     const result = await callAdminRpc<Record<string, unknown>>("admin_resend_run_digest", {
       actor_id: context.userId,
       run_id: params.runId,
       reason: parsed.reason,
       recipient_email: parsed.recipientEmail,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,
     });
 
     return NextResponse.json({

--- a/apps/admin/src/app/api/admin/runs/[runId]/documents/regenerate/route.ts
+++ b/apps/admin/src/app/api/admin/runs/[runId]/documents/regenerate/route.ts
@@ -18,12 +18,22 @@ export async function POST(request: Request, { params }: { params: { runId: stri
     return parsed;
   }
 
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return NextResponse.json({ error: "Tenant context unavailable" }, { status: 403 });
+  }
+
   try {
     const result = await callAdminRpc<Record<string, unknown>>("admin_regenerate_document", {
       actor_id: context.userId,
       run_id: params.runId,
       reason: parsed.reason,
       document_id: parsed.documentId,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,
     });
 
     return NextResponse.json({

--- a/apps/admin/src/app/api/admin/runs/[runId]/steps/[stepId]/due-date/route.ts
+++ b/apps/admin/src/app/api/admin/runs/[runId]/steps/[stepId]/due-date/route.ts
@@ -20,6 +20,13 @@ export async function PATCH(request: Request, { params }: { params: { runId: str
     return parsed;
   }
 
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return NextResponse.json({ error: "Tenant context unavailable" }, { status: 403 });
+  }
+
   try {
     const result = await callAdminRpc<Record<string, unknown>>("admin_update_step_due_date", {
       actor_id: context.userId,
@@ -27,6 +34,9 @@ export async function PATCH(request: Request, { params }: { params: { runId: str
       step_id: params.stepId,
       reason: parsed.reason,
       due_date: parsed.dueDate,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,
     });
 
     return NextResponse.json({

--- a/apps/admin/src/app/api/admin/runs/[runId]/steps/[stepId]/reassign/route.ts
+++ b/apps/admin/src/app/api/admin/runs/[runId]/steps/[stepId]/reassign/route.ts
@@ -18,6 +18,13 @@ export async function POST(request: Request, { params }: { params: { runId: stri
     return parsed;
   }
 
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return NextResponse.json({ error: "Tenant context unavailable" }, { status: 403 });
+  }
+
   try {
     const result = await callAdminRpc<Record<string, unknown>>("admin_reassign_step", {
       actor_id: context.userId,
@@ -25,6 +32,9 @@ export async function POST(request: Request, { params }: { params: { runId: stri
       step_id: params.stepId,
       reason: parsed.reason,
       assignee_id: parsed.assigneeId,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,
     });
 
     return NextResponse.json({

--- a/apps/admin/src/app/api/admin/runs/[runId]/steps/[stepId]/status/route.ts
+++ b/apps/admin/src/app/api/admin/runs/[runId]/steps/[stepId]/status/route.ts
@@ -20,6 +20,13 @@ export async function PATCH(request: Request, { params }: { params: { runId: str
     return parsed;
   }
 
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return NextResponse.json({ error: "Tenant context unavailable" }, { status: 403 });
+  }
+
   try {
     const result = await callAdminRpc<Record<string, unknown>>("admin_update_step_status", {
       actor_id: context.userId,
@@ -27,6 +34,9 @@ export async function PATCH(request: Request, { params }: { params: { runId: str
       step_id: params.stepId,
       reason: parsed.reason,
       status: parsed.status,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,
     });
 
     return NextResponse.json({

--- a/apps/admin/src/app/api/admin/secrets/bindings/[bindingId]/route.ts
+++ b/apps/admin/src/app/api/admin/secrets/bindings/[bindingId]/route.ts
@@ -19,6 +19,13 @@ export async function PATCH(request: Request, { params }: { params: { bindingId:
     return parsed;
   }
 
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return NextResponse.json({ error: "Tenant context unavailable" }, { status: 403 });
+  }
+
   try {
     const result = await callAdminRpc<Record<string, unknown>>("admin_update_secret_alias", {
       actor_id: context.userId,
@@ -26,6 +33,9 @@ export async function PATCH(request: Request, { params }: { params: { bindingId:
       reason: parsed.reason,
       description: parsed.description ?? null,
       external_id: parsed.externalId ?? null,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,
     });
 
     return NextResponse.json({
@@ -61,12 +71,22 @@ export async function DELETE(request: Request, { params }: { params: { bindingId
     return NextResponse.json({ error: "Second approver must be another admin" }, { status: 400 });
   }
 
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return NextResponse.json({ error: "Tenant context unavailable" }, { status: 403 });
+  }
+
   try {
     const result = await callAdminRpc<Record<string, unknown>>("admin_remove_secret_alias", {
       actor_id: context.userId,
       binding_id: params.bindingId,
       reason: parsed.reason,
       second_actor_id: secondActorId,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,
     });
 
     return NextResponse.json({

--- a/apps/admin/src/app/api/admin/secrets/bindings/[bindingId]/test/route.ts
+++ b/apps/admin/src/app/api/admin/secrets/bindings/[bindingId]/test/route.ts
@@ -17,11 +17,21 @@ export async function POST(request: Request, { params }: { params: { bindingId: 
     return parsed;
   }
 
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return NextResponse.json({ error: "Tenant context unavailable" }, { status: 403 });
+  }
+
   try {
     const result = await callAdminRpc<Record<string, unknown>>("admin_test_secret_alias", {
       actor_id: context.userId,
       binding_id: params.bindingId,
       reason: parsed.reason,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,
     });
 
     return NextResponse.json({

--- a/apps/admin/src/app/api/admin/secrets/bindings/route.ts
+++ b/apps/admin/src/app/api/admin/secrets/bindings/route.ts
@@ -27,6 +27,13 @@ export async function POST(request: Request) {
     return parsed;
   }
 
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId ?? parsed.orgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId ?? parsed.orgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return NextResponse.json({ error: "Tenant context unavailable" }, { status: 403 });
+  }
+
   try {
     const result = await callAdminRpc<Record<string, unknown>>("admin_bind_secret_alias", {
       actor_id: context.userId,
@@ -36,6 +43,9 @@ export async function POST(request: Request) {
       provider: parsed.provider,
       external_id: parsed.externalId,
       description: parsed.description ?? null,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: parsed.orgId,
     });
 
     return NextResponse.json({

--- a/apps/admin/src/app/api/admin/step-types/[stepTypeId]/publish/route.ts
+++ b/apps/admin/src/app/api/admin/step-types/[stepTypeId]/publish/route.ts
@@ -33,6 +33,13 @@ export async function POST(request: Request, { params }: { params: { stepTypeId:
     return jsonError(422, "Version identifier is required");
   }
 
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return jsonError(403, "Tenant context unavailable");
+  }
+
   try {
     const result = await callAdminRpc<Record<string, unknown>>("admin_publish_step_type_version", {
       reason: payload.reason,
@@ -40,6 +47,9 @@ export async function POST(request: Request, { params }: { params: { stepTypeId:
       step_type_id: stepTypeId,
       version_id: payload.version,
       changelog: payload.changelog ?? null,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,
     });
 
     return NextResponse.json({

--- a/apps/admin/src/app/api/admin/step-types/[stepTypeId]/route.ts
+++ b/apps/admin/src/app/api/admin/step-types/[stepTypeId]/route.ts
@@ -23,12 +23,22 @@ export async function PATCH(request: Request, { params }: { params: { stepTypeId
     return parsed;
   }
 
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return jsonError(403, "Tenant context unavailable");
+  }
+
   try {
     const result = await callAdminRpc<Record<string, unknown>>("admin_update_step_type", {
       reason: parsed.reason,
       actor_id: context.userId,
       step_type_id: stepTypeId,
       patch: parsed.patch,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,
     });
 
     return NextResponse.json({

--- a/apps/admin/src/app/api/admin/step-types/[stepTypeId]/secret-bindings/[bindingId]/route.ts
+++ b/apps/admin/src/app/api/admin/step-types/[stepTypeId]/secret-bindings/[bindingId]/route.ts
@@ -39,6 +39,13 @@ export async function PATCH(
     return jsonError(422, "Binding patch payload is required");
   }
 
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return jsonError(403, "Tenant context unavailable");
+  }
+
   try {
     const result = await callAdminRpc<Record<string, unknown>>("admin_update_tenant_secret_binding", {
       reason: payload.reason,
@@ -46,6 +53,9 @@ export async function PATCH(
       step_type_id: stepTypeId,
       binding_id: bindingId,
       patch: payload.patch,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,
     });
 
     return NextResponse.json({
@@ -85,12 +95,22 @@ export async function DELETE(
     return jsonError(422, "Reason code is required", { validationErrors: ["Reason code is required"] });
   }
 
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return jsonError(403, "Tenant context unavailable");
+  }
+
   try {
     const result = await callAdminRpc<Record<string, unknown>>("admin_unbind_tenant_secret_alias", {
       reason: payload.reason,
       actor_id: context.userId,
       step_type_id: stepTypeId,
       binding_id: bindingId,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,
     });
 
     return NextResponse.json({

--- a/apps/admin/src/app/api/admin/step-types/[stepTypeId]/secret-bindings/route.ts
+++ b/apps/admin/src/app/api/admin/step-types/[stepTypeId]/secret-bindings/route.ts
@@ -38,6 +38,13 @@ export async function POST(request: Request, { params }: { params: { stepTypeId:
     return jsonError(422, "Binding org, alias, provider, and reference are required");
   }
 
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return jsonError(403, "Tenant context unavailable");
+  }
+
   try {
     const result = await callAdminRpc<Record<string, unknown>>("admin_bind_tenant_secret_alias", {
       reason: payload.reason,
@@ -47,6 +54,9 @@ export async function POST(request: Request, { params }: { params: { stepTypeId:
       alias: binding.alias,
       provider: binding.provider,
       external_id: binding.external_id,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,
     });
 
     return NextResponse.json({

--- a/apps/admin/src/app/api/admin/step-types/[stepTypeId]/tenants/[installId]/route.ts
+++ b/apps/admin/src/app/api/admin/step-types/[stepTypeId]/tenants/[installId]/route.ts
@@ -41,6 +41,13 @@ export async function PATCH(
     return jsonError(422, "Install patch payload is required");
   }
 
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return jsonError(403, "Tenant context unavailable");
+  }
+
   try {
     const result = await callAdminRpc<Record<string, unknown>>("admin_update_tenant_step_type_install", {
       reason: payload.reason,
@@ -48,6 +55,9 @@ export async function PATCH(
       step_type_id: stepTypeId,
       install_id: installId,
       patch: payload.patch,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,
     });
 
     return NextResponse.json({
@@ -89,12 +99,22 @@ export async function DELETE(
     return jsonError(422, "Reason code is required", { validationErrors: ["Reason code is required"] });
   }
 
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return jsonError(403, "Tenant context unavailable");
+  }
+
   try {
     const result = await callAdminRpc<Record<string, unknown>>("admin_disable_tenant_step_type", {
       reason: payload.reason,
       actor_id: context.userId,
       step_type_id: stepTypeId,
       install_id: installId,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,
     });
 
     return NextResponse.json({

--- a/apps/admin/src/app/api/admin/step-types/[stepTypeId]/tenants/route.ts
+++ b/apps/admin/src/app/api/admin/step-types/[stepTypeId]/tenants/route.ts
@@ -41,6 +41,13 @@ export async function POST(request: Request, { params }: { params: { stepTypeId:
     return jsonError(422, "Version id is required when not following latest");
   }
 
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return jsonError(403, "Tenant context unavailable");
+  }
+
   try {
     const result = await callAdminRpc<Record<string, unknown>>("admin_enable_tenant_step_type", {
       reason: payload.reason,
@@ -49,6 +56,9 @@ export async function POST(request: Request, { params }: { params: { stepTypeId:
       org_slug: install.org_slug,
       version_id: install.version_id ?? null,
       follow_latest: install.follow_latest ?? false,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,
     });
 
     return NextResponse.json({

--- a/apps/admin/src/app/api/admin/step-types/route.ts
+++ b/apps/admin/src/app/api/admin/step-types/route.ts
@@ -18,11 +18,21 @@ export async function POST(request: Request) {
     return parsed;
   }
 
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return jsonError(403, "Tenant context unavailable");
+  }
+
   try {
     const result = await callAdminRpc<Record<string, unknown>>("admin_create_step_type", {
       reason: parsed.reason,
       actor_id: context.userId,
       step_type: parsed.stepType,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,
     });
 
     return NextResponse.json({

--- a/apps/admin/src/app/api/admin/temporal/runs/[runId]/cancel/route.ts
+++ b/apps/admin/src/app/api/admin/temporal/runs/[runId]/cancel/route.ts
@@ -27,12 +27,22 @@ export async function POST(request: Request, { params }: { params: { runId: stri
     return NextResponse.json({ error: "Cancellation does not require second approval" }, { status: 400 });
   }
 
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return NextResponse.json({ error: "Tenant context unavailable" }, { status: 403 });
+  }
+
   try {
     const result = await callAdminRpc<Record<string, unknown>>("admin_temporal_cancel", {
       actor_id: context.userId,
       run_id: params.runId,
       reason: parsed.reason,
       second_actor_id: parsed.approvedBy,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,
     });
 
     return NextResponse.json({

--- a/apps/admin/src/app/api/admin/temporal/runs/[runId]/retry/route.ts
+++ b/apps/admin/src/app/api/admin/temporal/runs/[runId]/retry/route.ts
@@ -18,12 +18,22 @@ export async function POST(request: Request, { params }: { params: { runId: stri
     return parsed;
   }
 
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return NextResponse.json({ error: "Tenant context unavailable" }, { status: 403 });
+  }
+
   try {
     const result = await callAdminRpc<Record<string, unknown>>("admin_temporal_retry", {
       actor_id: context.userId,
       run_id: params.runId,
       reason: parsed.reason,
       activity_id: parsed.activityId,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,
     });
 
     return NextResponse.json({

--- a/apps/admin/src/app/api/admin/temporal/runs/[runId]/signal/route.ts
+++ b/apps/admin/src/app/api/admin/temporal/runs/[runId]/signal/route.ts
@@ -19,6 +19,13 @@ export async function POST(request: Request, { params }: { params: { runId: stri
     return parsed;
   }
 
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return NextResponse.json({ error: "Tenant context unavailable" }, { status: 403 });
+  }
+
   try {
     const result = await callAdminRpc<Record<string, unknown>>("admin_temporal_signal", {
       actor_id: context.userId,
@@ -26,6 +33,9 @@ export async function POST(request: Request, { params }: { params: { runId: stri
       reason: parsed.reason,
       signal: parsed.signal,
       payload: parsed.payload,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,
     });
 
     return NextResponse.json({

--- a/packages/db/migrations/202501200001_tenant_scoping.sql
+++ b/packages/db/migrations/202501200001_tenant_scoping.sql
@@ -1,0 +1,161 @@
+-- Add tenant scoping columns across core tables
+alter table organisations
+  add column if not exists tenant_org_id uuid;
+
+update organisations
+set tenant_org_id = id
+where tenant_org_id is null;
+
+alter table organisations
+  alter column tenant_org_id set not null;
+
+alter table organisations
+  add constraint if not exists organisations_tenant_org_id_fkey
+    foreign key (tenant_org_id)
+    references organisations(id);
+
+alter table engagements
+  add column if not exists tenant_org_id uuid,
+  add column if not exists subject_org_id uuid;
+
+update engagements
+set tenant_org_id = coalesce(tenant_org_id, engager_org_id);
+
+update engagements
+set subject_org_id = coalesce(subject_org_id, client_org_id);
+
+alter table engagements
+  alter column tenant_org_id set not null;
+
+alter table engagements
+  add constraint if not exists engagements_tenant_org_id_fkey
+    foreign key (tenant_org_id)
+    references organisations(id);
+
+alter table engagements
+  add constraint if not exists engagements_subject_org_id_fkey
+    foreign key (subject_org_id)
+    references organisations(id);
+
+alter table workflow_runs
+  add column if not exists tenant_org_id uuid;
+
+update workflow_runs wr
+set tenant_org_id = coalesce(wr.tenant_org_id, wr.engager_org_id);
+
+alter table workflow_runs
+  alter column tenant_org_id set not null;
+
+alter table workflow_runs
+  add constraint if not exists workflow_runs_tenant_org_id_fkey
+    foreign key (tenant_org_id)
+    references organisations(id);
+
+alter table steps
+  add column if not exists tenant_org_id uuid,
+  add column if not exists subject_org_id uuid;
+
+update steps s
+set tenant_org_id = wr.tenant_org_id,
+    subject_org_id = coalesce(s.subject_org_id, wr.subject_org_id)
+from workflow_runs wr
+where wr.id = s.run_id;
+
+alter table steps
+  alter column tenant_org_id set not null;
+
+alter table steps
+  add constraint if not exists steps_tenant_org_id_fkey
+    foreign key (tenant_org_id)
+    references organisations(id);
+
+alter table steps
+  add constraint if not exists steps_subject_org_id_fkey
+    foreign key (subject_org_id)
+    references organisations(id);
+
+alter table documents
+  add column if not exists tenant_org_id uuid,
+  add column if not exists subject_org_id uuid;
+
+update documents d
+set tenant_org_id = wr.tenant_org_id,
+    subject_org_id = coalesce(d.subject_org_id, wr.subject_org_id)
+from workflow_runs wr
+where wr.id = d.run_id;
+
+alter table documents
+  alter column tenant_org_id set not null;
+
+alter table documents
+  add constraint if not exists documents_tenant_org_id_fkey
+    foreign key (tenant_org_id)
+    references organisations(id);
+
+alter table documents
+  add constraint if not exists documents_subject_org_id_fkey
+    foreign key (subject_org_id)
+    references organisations(id);
+
+alter table admin_actions
+  add column if not exists tenant_org_id uuid,
+  add column if not exists subject_org_id uuid;
+
+update admin_actions aa
+set tenant_org_id = coalesce(tenant_org_id, (
+  select wr.tenant_org_id
+  from workflow_runs wr
+  where aa.payload ? 'run_id'
+    and (aa.payload ->> 'run_id') ~* '^[0-9a-f-]{36}$'
+    and (aa.payload ->> 'run_id')::uuid = wr.id
+  limit 1
+));
+
+update admin_actions aa
+set subject_org_id = coalesce(subject_org_id, (
+  select wr.subject_org_id
+  from workflow_runs wr
+  where aa.payload ? 'run_id'
+    and (aa.payload ->> 'run_id') ~* '^[0-9a-f-]{36}$'
+    and (aa.payload ->> 'run_id')::uuid = wr.id
+  limit 1
+));
+
+alter table admin_actions
+  alter column tenant_org_id set not null;
+
+alter table admin_actions
+  add constraint if not exists admin_actions_tenant_org_id_fkey
+    foreign key (tenant_org_id)
+    references organisations(id);
+
+alter table admin_actions
+  add constraint if not exists admin_actions_subject_org_id_fkey
+    foreign key (subject_org_id)
+    references organisations(id);
+
+alter table audit_log
+  add column if not exists tenant_org_id uuid,
+  add column if not exists subject_org_id uuid;
+
+update audit_log al
+set tenant_org_id = coalesce(al.tenant_org_id, wr.tenant_org_id),
+    subject_org_id = coalesce(al.subject_org_id, wr.subject_org_id)
+from workflow_runs wr
+where wr.id = al.run_id;
+
+update audit_log
+set tenant_org_id = coalesce(tenant_org_id, actor_org_id, on_behalf_of_org_id);
+
+alter table audit_log
+  alter column tenant_org_id set not null;
+
+alter table audit_log
+  add constraint if not exists audit_log_tenant_org_id_fkey
+    foreign key (tenant_org_id)
+    references organisations(id);
+
+alter table audit_log
+  add constraint if not exists audit_log_subject_org_id_fkey
+    foreign key (subject_org_id)
+    references organisations(id);

--- a/packages/db/seeds.sql
+++ b/packages/db/seeds.sql
@@ -1,3 +1,3 @@
-insert into organisations (id, name, slug) values
-  ('00000000-0000-0000-0000-0000000000a1','Company A (Accountants)','company-a'),
-  ('00000000-0000-0000-0000-0000000000b1','Company X (Client)','company-x');
+insert into organisations (id, tenant_org_id, name, slug) values
+  ('00000000-0000-0000-0000-0000000000a1','00000000-0000-0000-0000-0000000000a1','Company A (Accountants)','company-a'),
+  ('00000000-0000-0000-0000-0000000000b1','00000000-0000-0000-0000-0000000000a1','Company X (Client)','company-x');

--- a/packages/types/src/supabase.ts
+++ b/packages/types/src/supabase.ts
@@ -139,23 +139,34 @@ export type Database = {
       organisations: {
         Row: {
           id: string;
+          tenant_org_id: string;
           name: string;
           slug: string;
           created_at: string | null;
         };
         Insert: {
           id?: string;
+          tenant_org_id: string;
           name: string;
           slug: string;
           created_at?: string | null;
         };
         Update: {
           id?: string;
+          tenant_org_id?: string;
           name?: string;
           slug?: string;
           created_at?: string | null;
         };
-        Relationships: [];
+        Relationships: [
+          {
+            foreignKeyName: "organisations_tenant_org_id_fkey";
+            columns: ["tenant_org_id"];
+            isOneToOne: false;
+            referencedRelation: "organisations";
+            referencedColumns: ["id"];
+          }
+        ];
       };
       users: {
         Row: {
@@ -286,6 +297,7 @@ export type Database = {
           workflow_def_id: string | null;
           subject_org_id: string;
           engager_org_id: string | null;
+          tenant_org_id: string;
           status: "draft" | "active" | "done" | "archived";
           orchestration_provider: string;
           orchestration_workflow_id: string | null;
@@ -298,6 +310,7 @@ export type Database = {
           workflow_def_id?: string | null;
           subject_org_id: string;
           engager_org_id?: string | null;
+          tenant_org_id: string;
           status?: "draft" | "active" | "done" | "archived";
           orchestration_provider?: string;
           orchestration_workflow_id?: string | null;
@@ -310,6 +323,7 @@ export type Database = {
           workflow_def_id?: string | null;
           subject_org_id?: string;
           engager_org_id?: string | null;
+          tenant_org_id?: string;
           status?: "draft" | "active" | "done" | "archived";
           orchestration_provider?: string;
           orchestration_workflow_id?: string | null;
@@ -340,6 +354,13 @@ export type Database = {
             referencedColumns: ["id"];
           },
           {
+            foreignKeyName: "workflow_runs_tenant_org_id_fkey";
+            columns: ["tenant_org_id"];
+            isOneToOne: false;
+            referencedRelation: "organisations";
+            referencedColumns: ["id"];
+          },
+          {
             foreignKeyName: "workflow_runs_workflow_def_id_fkey";
             columns: ["workflow_def_id"];
             isOneToOne: false;
@@ -352,6 +373,8 @@ export type Database = {
         Row: {
           id: string;
           run_id: string;
+          tenant_org_id: string;
+          subject_org_id: string | null;
           key: string;
           title: string;
           status: "todo" | "in_progress" | "waiting" | "blocked" | "done";
@@ -365,6 +388,8 @@ export type Database = {
         Insert: {
           id?: string;
           run_id: string;
+          tenant_org_id: string;
+          subject_org_id?: string | null;
           key: string;
           title: string;
           status?: "todo" | "in_progress" | "waiting" | "blocked" | "done";
@@ -378,6 +403,8 @@ export type Database = {
         Update: {
           id?: string;
           run_id?: string;
+          tenant_org_id?: string;
+          subject_org_id?: string | null;
           key?: string;
           title?: string;
           status?: "todo" | "in_progress" | "waiting" | "blocked" | "done";
@@ -408,6 +435,20 @@ export type Database = {
             columns: ["step_type_version_id"];
             isOneToOne: false;
             referencedRelation: "step_type_versions";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "steps_subject_org_id_fkey";
+            columns: ["subject_org_id"];
+            isOneToOne: false;
+            referencedRelation: "organisations";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "steps_tenant_org_id_fkey";
+            columns: ["tenant_org_id"];
+            isOneToOne: false;
+            referencedRelation: "organisations";
             referencedColumns: ["id"];
           }
         ];
@@ -764,6 +805,8 @@ export type Database = {
         Row: {
           id: string;
           run_id: string;
+          tenant_org_id: string;
+          subject_org_id: string | null;
           template_id: string | null;
           path: string | null;
           checksum: string | null;
@@ -772,6 +815,8 @@ export type Database = {
         Insert: {
           id?: string;
           run_id: string;
+          tenant_org_id: string;
+          subject_org_id?: string | null;
           template_id?: string | null;
           path?: string | null;
           checksum?: string | null;
@@ -780,6 +825,8 @@ export type Database = {
         Update: {
           id?: string;
           run_id?: string;
+          tenant_org_id?: string;
+          subject_org_id?: string | null;
           template_id?: string | null;
           path?: string | null;
           checksum?: string | null;
@@ -792,15 +839,32 @@ export type Database = {
             isOneToOne: false;
             referencedRelation: "workflow_runs";
             referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "documents_subject_org_id_fkey";
+            columns: ["subject_org_id"];
+            isOneToOne: false;
+            referencedRelation: "organisations";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "documents_tenant_org_id_fkey";
+            columns: ["tenant_org_id"];
+            isOneToOne: false;
+            referencedRelation: "organisations";
+            referencedColumns: ["id"];
           }
         ];
       };
       audit_log: {
         Row: {
           id: string;
+          tenant_org_id: string;
           actor_user_id: string | null;
           actor_org_id: string | null;
           on_behalf_of_org_id: string | null;
+          subject_org_id: string | null;
+          entity: string | null;
           run_id: string | null;
           step_id: string | null;
           action: string | null;
@@ -809,9 +873,12 @@ export type Database = {
         };
         Insert: {
           id?: string;
+          tenant_org_id: string;
           actor_user_id?: string | null;
           actor_org_id?: string | null;
           on_behalf_of_org_id?: string | null;
+          subject_org_id?: string | null;
+          entity?: string | null;
           run_id?: string | null;
           step_id?: string | null;
           action?: string | null;
@@ -820,9 +887,12 @@ export type Database = {
         };
         Update: {
           id?: string;
+          tenant_org_id?: string;
           actor_user_id?: string | null;
           actor_org_id?: string | null;
           on_behalf_of_org_id?: string | null;
+          subject_org_id?: string | null;
+          entity?: string | null;
           run_id?: string | null;
           step_id?: string | null;
           action?: string | null;
@@ -863,6 +933,111 @@ export type Database = {
             columns: ["step_id"];
             isOneToOne: false;
             referencedRelation: "steps";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "audit_log_subject_org_id_fkey";
+            columns: ["subject_org_id"];
+            isOneToOne: false;
+            referencedRelation: "organisations";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "audit_log_tenant_org_id_fkey";
+            columns: ["tenant_org_id"];
+            isOneToOne: false;
+            referencedRelation: "organisations";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+      admin_actions: {
+        Row: {
+          id: string;
+          tenant_org_id: string;
+          actor_id: string;
+          actor_org_id: string | null;
+          on_behalf_of_org_id: string | null;
+          subject_org_id: string | null;
+          action: string;
+          reason: string;
+          payload: Json;
+          requires_second_approval: boolean;
+          second_actor_id: string | null;
+          created_at: string;
+          approved_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          tenant_org_id: string;
+          actor_id: string;
+          actor_org_id?: string | null;
+          on_behalf_of_org_id?: string | null;
+          subject_org_id?: string | null;
+          action: string;
+          reason: string;
+          payload?: Json;
+          requires_second_approval?: boolean;
+          second_actor_id?: string | null;
+          created_at?: string;
+          approved_at?: string | null;
+        };
+        Update: {
+          id?: string;
+          tenant_org_id?: string;
+          actor_id?: string;
+          actor_org_id?: string | null;
+          on_behalf_of_org_id?: string | null;
+          subject_org_id?: string | null;
+          action?: string;
+          reason?: string;
+          payload?: Json;
+          requires_second_approval?: boolean;
+          second_actor_id?: string | null;
+          created_at?: string;
+          approved_at?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "admin_actions_actor_id_fkey";
+            columns: ["actor_id"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "admin_actions_actor_org_id_fkey";
+            columns: ["actor_org_id"];
+            isOneToOne: false;
+            referencedRelation: "organisations";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "admin_actions_on_behalf_of_org_id_fkey";
+            columns: ["on_behalf_of_org_id"];
+            isOneToOne: false;
+            referencedRelation: "organisations";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "admin_actions_subject_org_id_fkey";
+            columns: ["subject_org_id"];
+            isOneToOne: false;
+            referencedRelation: "organisations";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "admin_actions_tenant_org_id_fkey";
+            columns: ["tenant_org_id"];
+            isOneToOne: false;
+            referencedRelation: "organisations";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "admin_actions_second_actor_id_fkey";
+            columns: ["second_actor_id"];
+            isOneToOne: false;
+            referencedRelation: "users";
             referencedColumns: ["id"];
           }
         ];

--- a/scripts/dsr-jobs.ts
+++ b/scripts/dsr-jobs.ts
@@ -143,7 +143,11 @@ async function main() {
         .update({ status: "acknowledged", ack_sent_at: ackSentAt, updated_at: ackSentAt })
         .eq("id", request.id);
       await client.from("audit_log").insert({
+        tenant_org_id: request.tenant_org_id,
         actor_org_id: request.tenant_org_id,
+        on_behalf_of_org_id: request.subject_org_id ?? null,
+        subject_org_id: request.subject_org_id ?? null,
+        entity: "dsr_request",
         action: "dsr.request.acknowledged",
         meta_json: { request_id: request.id, ack_sent_at: ackSentAt }
       });
@@ -178,7 +182,11 @@ async function main() {
         .update({ status: "escalated", updated_at: nowIso })
         .eq("id", request.id);
       await client.from("audit_log").insert({
+        tenant_org_id: request.tenant_org_id,
         actor_org_id: request.tenant_org_id,
+        on_behalf_of_org_id: request.subject_org_id ?? null,
+        subject_org_id: request.subject_org_id ?? null,
+        entity: "dsr_request",
         action: "dsr.request.escalated",
         meta_json: { request_id: request.id, due_at: request.due_at }
       });


### PR DESCRIPTION
## Summary
- ensure admin server actions load DSR subject org data and include tenant-scoped audit metadata
- extend the admin context helper to surface tenant/actor org IDs and apply the new guardrails when calling RPCs across admin APIs
- update admin API handlers and seeds to pass tenant, actor, and on-behalf org identifiers required by the tenant-scoped schema

## Testing
- pnpm vitest run apps/admin/src/app/api/admin/__tests__/cancel-run.test.ts *(fails: command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dffc0f0dd88324ae1d9659add0bb82