### PR TITLE
feat: scaffold Stripe billing sync and portal views

### DIFF
--- a/apps/portal/messages/en-IE/common.json
+++ b/apps/portal/messages/en-IE/common.json
@@ -30,6 +30,70 @@
       "waiting": "Waiting",
       "blocked": "Blocked",
       "done": "Done"
+    },
+    "billingCardTitle": "Billing overview",
+    "billingCardDescription": "Check your plan, renewal date, and payment status at a glance.",
+    "billingCardCta": "View billing"
+  },
+  "billing": {
+    "title": "Subscription & billing",
+    "description": "Review your current Stripe subscription, billing mode, and renewal dates.",
+    "lastUpdated": "Last updated {date, date, medium}",
+    "status": {
+      "trialing": "Trialing",
+      "active": "Active",
+      "incomplete": "Incomplete",
+      "incomplete_expired": "Trial expired",
+      "past_due": "Past due",
+      "canceled": "Canceled",
+      "unpaid": "Unpaid",
+      "paused": "Paused",
+      "unknown": "Unknown"
+    },
+    "mode": {
+      "direct": "Direct billing",
+      "partner_managed": "Partner managed"
+    },
+    "collection": {
+      "charge_automatically": "Automatic charges",
+      "send_invoice": "Send invoice"
+    },
+    "subscription": {
+      "heading": "Subscription details",
+      "customerId": "Customer ID",
+      "subscriptionId": "Subscription ID",
+      "billingMode": "Billing mode",
+      "collection": "Collection method",
+      "nextRenewal": "Next renewal",
+      "cancelAtPeriodEnd": "Cancel at period end",
+      "noRenewal": "Not scheduled",
+      "missing": "Not available"
+    },
+    "plan": {
+      "heading": "Plan",
+      "name": "Product",
+      "nickname": "Price nickname",
+      "amount": "Amount",
+      "interval": "Interval",
+      "recurring": "Every {count, plural, one {{interval}} other {{count} {interval}}}",
+      "oneTime": "One-time",
+      "active": "Active",
+      "unknown": "Unknown",
+      "pending": "Pending",
+      "intervalLabels": {
+        "day": "day",
+        "week": "week",
+        "month": "month",
+        "year": "year"
+      }
+    },
+    "empty": {
+      "heading": "No subscription found",
+      "body": "Provision a plan via the billing API to see subscription status here."
+    },
+    "boolean": {
+      "yes": "Yes",
+      "no": "No"
     }
   },
   "actingFor": {

--- a/apps/portal/messages/ga-IE/common.json
+++ b/apps/portal/messages/ga-IE/common.json
@@ -30,6 +30,70 @@
       "waiting": "Ag fanacht",
       "blocked": "Blocáilte",
       "done": "Críochnaithe"
+    },
+    "billingCardTitle": "Forbhreathnú billeála",
+    "billingCardDescription": "Seiceáil do phlean, dáta athnuachana agus stádas íocaíochta ar bhreathnú amháin.",
+    "billingCardCta": "Féach billeáil"
+  },
+  "billing": {
+    "title": "Síntiús agus billeáil",
+    "description": "Athbhreithnigh do shíntiús Stripe reatha, modh billeála agus dátaí athnuachana.",
+    "lastUpdated": "Nuashonraithe {date, date, medium}",
+    "status": {
+      "trialing": "Ar thriail",
+      "active": "Gníomhach",
+      "incomplete": "Neamhiomlán",
+      "incomplete_expired": "Triail imithe in éag",
+      "past_due": "As dáta",
+      "canceled": "Cealaithe",
+      "unpaid": "Gan íoc",
+      "paused": "Ar sos",
+      "unknown": "Anaithnid"
+    },
+    "mode": {
+      "direct": "Billeáil dhíreach",
+      "partner_managed": "Arna bhainistiú ag comhpháirtí"
+    },
+    "collection": {
+      "charge_automatically": "Muirearú uathoibríoch",
+      "send_invoice": "Seol sonrasc"
+    },
+    "subscription": {
+      "heading": "Sonraí síntiúis",
+      "customerId": "Aitheantas custaiméara",
+      "subscriptionId": "Aitheantas síntiúis",
+      "billingMode": "Modh billeála",
+      "collection": "Modh bailithe",
+      "nextRenewal": "Athnuachan eile",
+      "cancelAtPeriodEnd": "Cealaigh ag deireadh na tréimhse",
+      "noRenewal": "Gan sceideal",
+      "missing": "Níl ar fáil"
+    },
+    "plan": {
+      "heading": "Plean",
+      "name": "Táirge",
+      "nickname": "Leasainm praghais",
+      "amount": "Méid",
+      "interval": "Eatramh",
+      "recurring": "Gach {count, plural, one {{interval}} other {{count} {interval}}}",
+      "oneTime": "Aonuaire",
+      "active": "Gníomhach",
+      "unknown": "Anaithnid",
+      "pending": "Ar feitheamh",
+      "intervalLabels": {
+        "day": "lá",
+        "week": "seachtain",
+        "month": "mí",
+        "year": "bliain"
+      }
+    },
+    "empty": {
+      "heading": "Níor aimsíodh síntiús",
+      "body": "Soláthair plean tríd an API billeála chun stádas síntiúis a fheiceáil anseo."
+    },
+    "boolean": {
+      "yes": "Tá",
+      "no": "Níl"
     }
   },
   "actingFor": {

--- a/apps/portal/src/app/[locale]/billing/page.tsx
+++ b/apps/portal/src/app/[locale]/billing/page.tsx
@@ -1,0 +1,154 @@
+import { getTranslations } from "next-intl/server";
+import { Badge, Card, Flex, Heading, Separator, Text } from "@radix-ui/themes";
+import { loadTenantBillingOverview } from "../../../server/billing";
+
+function formatCurrency(amount: number, currency: string, locale: string) {
+  try {
+    return new Intl.NumberFormat(locale, {
+      style: "currency",
+      currency: currency.toUpperCase()
+    }).format(amount);
+  } catch {
+    return `${currency.toUpperCase()} ${amount.toFixed(2)}`;
+  }
+}
+
+function formatDate(iso: string, locale: string) {
+  try {
+    return new Intl.DateTimeFormat(locale, { dateStyle: "medium" }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+}
+
+export default async function BillingPage({
+  params
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "billing" });
+  const { overview } = await loadTenantBillingOverview();
+
+  const statusKey = (overview?.status ?? "unknown") as
+    | "trialing"
+    | "active"
+    | "incomplete"
+    | "incomplete_expired"
+    | "past_due"
+    | "canceled"
+    | "unpaid"
+    | "paused"
+    | "unknown";
+  const statusLabel = t(`status.${statusKey}`);
+  const billingModeLabel = t(`mode.${(overview?.billing_mode ?? "direct") as "direct" | "partner_managed"}`);
+  const latestUpdate = overview?.subscription_updated_at ?? overview?.tenant_updated_at ?? null;
+  const priceAmount =
+    overview?.unit_amount != null && overview?.currency
+      ? formatCurrency(overview.unit_amount / 100, overview.currency, locale)
+      : null;
+  const nextRenewal = overview?.current_period_end
+    ? formatDate(overview.current_period_end, locale)
+    : t("subscription.noRenewal");
+  const collectionMethodKey = (overview?.collection_method ?? "charge_automatically") as
+    | "charge_automatically"
+    | "send_invoice";
+  const collectionMethodLabel = t(`collection.${collectionMethodKey}`);
+  const intervalKey = overview?.interval ?? null;
+  const intervalLabel = intervalKey
+    ? t(`plan.intervalLabels.${intervalKey as "day" | "week" | "month" | "year"}`)
+    : null;
+
+  return (
+    <Flex direction="column" gap="4">
+      <Flex direction="column" gap="2">
+        <Heading size="6">{t("title")}</Heading>
+        <Text color="gray" size="3">
+          {t("description")}
+        </Text>
+        {latestUpdate ? (
+          <Text color="gray" size="2">
+            {t("lastUpdated", { date: new Date(latestUpdate) })}
+          </Text>
+        ) : null}
+      </Flex>
+
+      {overview ? (
+        <Flex direction="column" gap="4">
+          <Card variant="surface">
+            <Flex direction="column" gap="3">
+              <Flex align="center" justify="between" gap="3" wrap="wrap">
+                <Heading size="5">{t("subscription.heading")}</Heading>
+                <Badge color={statusKey === "active" ? "green" : statusKey === "trialing" ? "blue" : "amber"}>
+                  {statusLabel}
+                </Badge>
+              </Flex>
+              <Separator size="4" />
+              <Flex direction="column" gap="2">
+                <Text size="3">
+                  <strong>{t("subscription.customerId")}:</strong> {overview.stripe_customer_id ?? t("subscription.missing")}
+                </Text>
+                <Text size="3">
+                  <strong>{t("subscription.subscriptionId")}:</strong> {overview.stripe_subscription_id ?? t("subscription.missing")}
+                </Text>
+                <Text size="3">
+                  <strong>{t("subscription.billingMode")}:</strong> {billingModeLabel}
+                </Text>
+                <Text size="3">
+                  <strong>{t("subscription.collection")}:</strong> {collectionMethodLabel}
+                </Text>
+                <Text size="3">
+                  <strong>{t("subscription.nextRenewal")}:</strong> {nextRenewal}
+                </Text>
+                <Text size="3">
+                  <strong>{t("subscription.cancelAtPeriodEnd")}:</strong> {overview.cancel_at_period_end ? t("boolean.yes") : t("boolean.no")}
+                </Text>
+              </Flex>
+            </Flex>
+          </Card>
+
+          <Card variant="surface">
+            <Flex direction="column" gap="3">
+              <Heading size="5">{t("plan.heading")}</Heading>
+              <Separator size="4" />
+              <Flex direction="column" gap="2">
+                <Text size="3">
+                  <strong>{t("plan.name")}:</strong> {overview.product_name ?? t("plan.unknown")}
+                </Text>
+                <Text size="3">
+                  <strong>{t("plan.nickname")}:</strong> {overview.nickname ?? t("plan.unknown")}
+                </Text>
+                <Text size="3">
+                  <strong>{t("plan.amount")}:</strong> {priceAmount ?? t("plan.pending")}
+                </Text>
+                <Text size="3">
+                  <strong>{t("plan.interval")}:</strong>{" "}
+                  {intervalLabel
+                    ? t("plan.recurring", {
+                        count: overview.interval_count ?? 1,
+                        interval: intervalLabel
+                      })
+                    : t("plan.oneTime")}
+                </Text>
+                <Text size="3">
+                  <strong>{t("plan.active")}:</strong> {overview.price_active ? t("boolean.yes") : t("boolean.no")}
+                </Text>
+              </Flex>
+            </Flex>
+          </Card>
+        </Flex>
+      ) : (
+        <Card variant="surface">
+          <Flex direction="column" gap="3">
+            <Heading size="5">{t("empty.heading")}</Heading>
+            <Text size="3" color="gray">
+              {t("empty.body")}
+            </Text>
+          </Flex>
+        </Card>
+      )}
+    </Flex>
+  );
+}
+
+export const dynamic = "force-dynamic";

--- a/apps/portal/src/app/[locale]/page.tsx
+++ b/apps/portal/src/app/[locale]/page.tsx
@@ -65,6 +65,23 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
           </Flex>
         </section>
       </Card>
+      <Card asChild variant="surface" size="3">
+        <section aria-labelledby="home-billing-heading">
+          <Flex direction="column" gap="3">
+            <Heading id="home-billing-heading" size="4">
+              {tHome("billingCardTitle")}
+            </Heading>
+            <Text size="2" color="gray">
+              {tHome("billingCardDescription")}
+            </Text>
+            <Flex>
+              <Button asChild>
+                <Link href={`/${locale}/billing`}>{tHome("billingCardCta")}</Link>
+              </Button>
+            </Flex>
+          </Flex>
+        </section>
+      </Card>
     </Flex>
   );
 }

--- a/apps/portal/src/app/api/billing/provision/route.ts
+++ b/apps/portal/src/app/api/billing/provision/route.ts
@@ -1,0 +1,174 @@
+import { NextResponse } from "next/server";
+import type Stripe from "stripe";
+import {
+  createStripeSubscription,
+  ensureStripeCustomer,
+  StripeConfigurationError
+} from "@airnub/utils/billing";
+import {
+  getSupabaseClient,
+  SupabaseConfigurationError
+} from "../../../../server/supabase";
+
+interface ProvisionPayload {
+  tenantOrgId: string;
+  priceId: string;
+  customerEmail: string;
+  customerName?: string;
+  billingMode?: "direct" | "partner_managed";
+  partnerOrgId?: string | null;
+  metadata?: Record<string, string>;
+}
+
+function toIso(timestamp: number | null | undefined): string | null {
+  if (!timestamp) {
+    return null;
+  }
+  return new Date(timestamp * 1000).toISOString();
+}
+
+function isValidUuid(value: string | null | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+  return /^[0-9a-fA-F-]{36}$/.test(value.trim());
+}
+
+export async function POST(request: Request) {
+  let payload: ProvisionPayload;
+
+  try {
+    payload = (await request.json()) as ProvisionPayload;
+  } catch {
+    return NextResponse.json({ ok: false, error: "Invalid JSON payload" }, { status: 400 });
+  }
+
+  if (!payload.tenantOrgId || !payload.priceId || !payload.customerEmail) {
+    return NextResponse.json(
+      { ok: false, error: "tenantOrgId, priceId, and customerEmail are required" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const supabase = getSupabaseClient();
+
+    const membershipCheck = await supabase.rpc("assert_tenant_membership", {
+      target_tenant: payload.tenantOrgId
+    });
+
+    if (membershipCheck.error) {
+      return NextResponse.json({ ok: false, error: membershipCheck.error.message }, { status: 403 });
+    }
+
+    const { data: existingTenant, error: tenantLookupError } = await supabase
+      .from("billing_tenants")
+      .select("id, stripe_customer_id, billing_mode")
+      .eq("tenant_org_id", payload.tenantOrgId)
+      .maybeSingle();
+
+    if (tenantLookupError) {
+      return NextResponse.json({ ok: false, error: tenantLookupError.message }, { status: 400 });
+    }
+
+    const customer = await ensureStripeCustomer({
+      stripeCustomerId: existingTenant?.stripe_customer_id ?? null,
+      email: payload.customerEmail,
+      name: payload.customerName ?? null,
+      tenantOrgId: payload.tenantOrgId,
+      billingMode: payload.billingMode ?? existingTenant?.billing_mode ?? "direct",
+      partnerOrgId: isValidUuid(payload.partnerOrgId ?? null) ? payload.partnerOrgId ?? null : null,
+      defaultPriceId: payload.priceId,
+      metadata: payload.metadata
+    });
+
+    const tenantResult = await supabase.rpc("rpc_upsert_billing_tenant", {
+      p_tenant_org_id: payload.tenantOrgId,
+      p_stripe_customer_id: customer.id,
+      p_billing_mode: payload.billingMode ?? existingTenant?.billing_mode ?? "direct",
+      p_partner_org_id: isValidUuid(payload.partnerOrgId ?? null) ? payload.partnerOrgId ?? null : null,
+      p_default_price_id: payload.priceId,
+      p_metadata: {
+        ...(payload.metadata ?? {}),
+        tenant_org_id: payload.tenantOrgId,
+        price_id: payload.priceId
+      }
+    });
+
+    if (tenantResult.error) {
+      return NextResponse.json({ ok: false, error: tenantResult.error.message }, { status: 400 });
+    }
+
+    const subscription = await createStripeSubscription({
+      customerId: customer.id,
+      priceId: payload.priceId,
+      metadata: {
+        ...(payload.metadata ?? {}),
+        tenant_org_id: payload.tenantOrgId
+      }
+    });
+
+    const price = subscription.items.data[0]?.price ?? null;
+
+    if (price) {
+      const priceResult = await supabase.rpc("rpc_upsert_billing_price", {
+        p_stripe_price_id: price.id,
+        p_product_name:
+          typeof price.product === "string"
+            ? price.product
+            : price.product && "name" in price.product
+              ? (price.product as Stripe.Product).name
+              : price.nickname ?? "Stripe price",
+        p_nickname: price.nickname ?? null,
+        p_unit_amount: typeof price.unit_amount === "number" ? price.unit_amount : null,
+        p_currency: price.currency ?? "usd",
+        p_interval: price.recurring?.interval ?? null,
+        p_interval_count: price.recurring?.interval_count ?? null,
+        p_is_active: price.active,
+        p_metadata: price.metadata ?? {}
+      });
+
+      if (priceResult.error) {
+        return NextResponse.json({ ok: false, error: priceResult.error.message }, { status: 400 });
+      }
+    }
+
+    const subscriptionResult = await supabase.rpc("rpc_upsert_billing_subscription", {
+      p_tenant_org_id: payload.tenantOrgId,
+      p_billing_tenant_id: (tenantResult.data as { id?: string } | null)?.id ?? existingTenant?.id ?? null,
+      p_stripe_subscription_id: subscription.id,
+      p_status: subscription.status,
+      p_stripe_price_id: price?.id ?? payload.priceId,
+      p_current_period_start: toIso(subscription.current_period_start),
+      p_current_period_end: toIso(subscription.current_period_end),
+      p_cancel_at: toIso(subscription.cancel_at),
+      p_canceled_at: toIso(subscription.canceled_at),
+      p_cancel_at_period_end: subscription.cancel_at_period_end ?? false,
+      p_collection_method: subscription.collection_method ?? null,
+      p_latest_invoice_id:
+        typeof subscription.latest_invoice === "string"
+          ? subscription.latest_invoice
+          : subscription.latest_invoice?.id ?? null,
+      p_metadata: subscription.metadata ?? {}
+    });
+
+    if (subscriptionResult.error) {
+      return NextResponse.json({ ok: false, error: subscriptionResult.error.message }, { status: 400 });
+    }
+
+    return NextResponse.json({
+      ok: true,
+      customerId: customer.id,
+      subscriptionId: subscription.id,
+      status: subscription.status
+    });
+  } catch (error) {
+    if (error instanceof SupabaseConfigurationError || error instanceof StripeConfigurationError) {
+      return NextResponse.json({ ok: false, error: error.message }, { status: 503 });
+    }
+    return NextResponse.json({ ok: false, error: (error as Error).message }, { status: 500 });
+  }
+}
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";

--- a/apps/portal/src/app/api/stripe/webhook/route.ts
+++ b/apps/portal/src/app/api/stripe/webhook/route.ts
@@ -1,0 +1,256 @@
+import { NextResponse } from "next/server";
+import type Stripe from "stripe";
+import {
+  StripeConfigurationError,
+  StripeWebhookVerificationError,
+  verifyStripeWebhookSignature
+} from "@airnub/utils/billing";
+import {
+  getServiceSupabaseClient,
+  SupabaseServiceConfigurationError,
+  type ServiceSupabaseClient
+} from "@airnub/utils/supabase-service";
+
+function isDeletedCustomer(customer: Stripe.Customer | Stripe.DeletedCustomer): customer is Stripe.DeletedCustomer {
+  return (customer as Stripe.DeletedCustomer).deleted === true;
+}
+
+function normalizeTenantOrgId(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function toUuid(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+  const candidate = value.trim();
+  return /^[0-9a-fA-F-]{36}$/.test(candidate) ? candidate : null;
+}
+
+function coerceBillingMode(value: string | null | undefined): "direct" | "partner_managed" {
+  if (!value) {
+    return "direct";
+  }
+  const normalized = value.toLowerCase();
+  if (normalized === "partner" || normalized === "partner_managed") {
+    return "partner_managed";
+  }
+  return "direct";
+}
+
+async function upsertStripePrice(price: Stripe.Price, supabase: ServiceSupabaseClient) {
+  const recurring = price.recurring ?? undefined;
+  const productName =
+    typeof price.product === "string"
+      ? price.product
+      : price.product && "name" in price.product
+        ? (price.product as Stripe.Product).name
+        : price.nickname ?? "Stripe price";
+
+  const { error } = await supabase.rpc("rpc_upsert_billing_price", {
+    p_stripe_price_id: price.id,
+    p_product_name: productName,
+    p_nickname: price.nickname ?? null,
+    p_unit_amount: typeof price.unit_amount === "number" ? price.unit_amount : null,
+    p_currency: price.currency ?? "usd",
+    p_interval: recurring?.interval ?? null,
+    p_interval_count: recurring?.interval_count ?? null,
+    p_is_active: price.active,
+    p_metadata: price.metadata ?? {}
+  });
+
+  if (error) {
+    throw new Error(`Failed to upsert billing price: ${error.message}`);
+  }
+}
+
+async function resolveTenantContext(
+  supabase: ServiceSupabaseClient,
+  params: {
+    tenantOrgId?: string | null;
+    customerId?: string | null;
+  }
+): Promise<{ tenantOrgId: string; billingTenantId: string | null } | null> {
+  if (params.tenantOrgId) {
+    const { data, error } = await supabase
+      .from("billing_tenants")
+      .select("id, tenant_org_id")
+      .eq("tenant_org_id", params.tenantOrgId)
+      .maybeSingle();
+
+    if (error) {
+      throw new Error(`Unable to resolve billing tenant: ${error.message}`);
+    }
+
+    if (data?.tenant_org_id) {
+      return { tenantOrgId: data.tenant_org_id, billingTenantId: data.id ?? null };
+    }
+
+    return { tenantOrgId: params.tenantOrgId, billingTenantId: null };
+  }
+
+  if (params.customerId) {
+    const { data, error } = await supabase
+      .from("billing_tenants")
+      .select("id, tenant_org_id")
+      .eq("stripe_customer_id", params.customerId)
+      .maybeSingle();
+
+    if (error) {
+      throw new Error(`Unable to resolve billing tenant by customer id: ${error.message}`);
+    }
+
+    if (data?.tenant_org_id) {
+      return { tenantOrgId: data.tenant_org_id, billingTenantId: data.id ?? null };
+    }
+  }
+
+  return null;
+}
+
+async function upsertStripeCustomer(customer: Stripe.Customer, supabase: ServiceSupabaseClient) {
+  const metadata = customer.metadata ?? {};
+  const tenantOrgId = normalizeTenantOrgId(metadata.tenant_org_id ?? metadata.tenantOrgId);
+
+  if (!tenantOrgId) {
+    return;
+  }
+
+  const { error } = await supabase.rpc("rpc_upsert_billing_tenant", {
+    p_tenant_org_id: tenantOrgId,
+    p_stripe_customer_id: customer.id,
+    p_billing_mode: coerceBillingMode(metadata.billing_mode ?? metadata.billingMode),
+    p_partner_org_id: toUuid(metadata.partner_org_id ?? metadata.partnerOrgId),
+    p_default_price_id: metadata.default_price_id ?? metadata.defaultPriceId ?? null,
+    p_metadata: metadata
+  });
+
+  if (error) {
+    throw new Error(`Failed to upsert billing tenant: ${error.message}`);
+  }
+}
+
+function toIso(timestamp: number | null | undefined): string | null {
+  if (!timestamp) {
+    return null;
+  }
+  return new Date(timestamp * 1000).toISOString();
+}
+
+async function upsertStripeSubscription(
+  subscription: Stripe.Subscription,
+  supabase: ServiceSupabaseClient
+) {
+  const metadata = subscription.metadata ?? {};
+  const explicitTenantOrgId = normalizeTenantOrgId(metadata.tenant_org_id ?? metadata.tenantOrgId);
+  const context = await resolveTenantContext(supabase, {
+    tenantOrgId: explicitTenantOrgId,
+    customerId: typeof subscription.customer === "string" ? subscription.customer : null
+  });
+
+  if (!context) {
+    return;
+  }
+
+  const primaryPrice = subscription.items.data[0]?.price;
+  if (primaryPrice) {
+    await upsertStripePrice(primaryPrice, supabase);
+  }
+
+  const latestInvoiceId = (() => {
+    if (!subscription.latest_invoice) {
+      return null;
+    }
+    return typeof subscription.latest_invoice === "string"
+      ? subscription.latest_invoice
+      : subscription.latest_invoice.id;
+  })();
+
+  const { error } = await supabase.rpc("rpc_upsert_billing_subscription", {
+    p_tenant_org_id: context.tenantOrgId,
+    p_billing_tenant_id: context.billingTenantId,
+    p_stripe_subscription_id: subscription.id,
+    p_status: subscription.status,
+    p_stripe_price_id: primaryPrice?.id ?? null,
+    p_current_period_start: toIso(subscription.current_period_start),
+    p_current_period_end: toIso(subscription.current_period_end),
+    p_cancel_at: toIso(subscription.cancel_at),
+    p_canceled_at: toIso(subscription.canceled_at),
+    p_cancel_at_period_end: subscription.cancel_at_period_end ?? false,
+    p_collection_method: subscription.collection_method ?? null,
+    p_latest_invoice_id: latestInvoiceId,
+    p_metadata: metadata
+  });
+
+  if (error) {
+    throw new Error(`Failed to upsert billing subscription: ${error.message}`);
+  }
+}
+
+async function handleStripeEvent(event: Stripe.Event, supabase: ServiceSupabaseClient) {
+  switch (event.type) {
+    case "price.created":
+    case "price.updated":
+    case "price.deleted": {
+      if (event.data.object && (event.data.object as Stripe.Price).object === "price") {
+        const price = event.data.object as Stripe.Price;
+        await upsertStripePrice(price, supabase);
+      }
+      break;
+    }
+    case "customer.created":
+    case "customer.updated": {
+      if (!isDeletedCustomer(event.data.object as Stripe.Customer | Stripe.DeletedCustomer)) {
+        await upsertStripeCustomer(event.data.object as Stripe.Customer, supabase);
+      }
+      break;
+    }
+    case "customer.subscription.created":
+    case "customer.subscription.updated":
+    case "customer.subscription.deleted": {
+      await upsertStripeSubscription(event.data.object as Stripe.Subscription, supabase);
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+export async function POST(request: Request) {
+  let event: Stripe.Event;
+  const rawBody = await request.text();
+
+  try {
+    event = verifyStripeWebhookSignature(rawBody, request.headers.get("stripe-signature"));
+  } catch (error) {
+    if (error instanceof StripeWebhookVerificationError || error instanceof StripeConfigurationError) {
+      return NextResponse.json({ ok: false, error: error.message }, { status: 400 });
+    }
+    return NextResponse.json({ ok: false, error: (error as Error).message }, { status: 500 });
+  }
+
+  let supabase: ServiceSupabaseClient;
+  try {
+    supabase = getServiceSupabaseClient();
+  } catch (error) {
+    if (error instanceof SupabaseServiceConfigurationError) {
+      return NextResponse.json({ ok: false, error: error.message }, { status: 503 });
+    }
+    throw error;
+  }
+
+  try {
+    await handleStripeEvent(event, supabase);
+    return NextResponse.json({ ok: true, received: true });
+  } catch (error) {
+    console.error("Stripe webhook handling failed", error);
+    return NextResponse.json({ ok: false, error: (error as Error).message }, { status: 500 });
+  }
+}
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";

--- a/apps/portal/src/server/billing.ts
+++ b/apps/portal/src/server/billing.ts
@@ -1,0 +1,41 @@
+import { headers } from "next/headers";
+import { getSupabaseClient, SupabaseConfigurationError } from "./supabase";
+import type { Database } from "@airnub/types";
+import { getTenantBrandingFromHeaders } from "../lib/tenant-branding";
+
+export type BillingSubscriptionOverviewRow =
+  Database["public"]["Views"]["billing_subscription_overview"]["Row"];
+
+export interface TenantBillingOverviewResult {
+  tenantOrgId: string;
+  overview: BillingSubscriptionOverviewRow | null;
+}
+
+export async function loadTenantBillingOverview(): Promise<TenantBillingOverviewResult> {
+  const headerStore = headers();
+  const branding = getTenantBrandingFromHeaders(headerStore);
+
+  try {
+    const supabase = getSupabaseClient();
+    const { data, error } = await supabase
+      .from("billing_subscription_overview")
+      .select("*")
+      .eq("tenant_org_id", branding.tenantOrgId)
+      .maybeSingle();
+
+    if (error) {
+      throw new Error(`Unable to load billing overview: ${error.message}`);
+    }
+
+    return {
+      tenantOrgId: branding.tenantOrgId,
+      overview: (data as BillingSubscriptionOverviewRow | null) ?? null
+    };
+  } catch (error) {
+    if (error instanceof SupabaseConfigurationError) {
+      console.error(error.message);
+      return { tenantOrgId: branding.tenantOrgId, overview: null };
+    }
+    throw error;
+  }
+}

--- a/packages/db/migrations/202502010001_billing_scaffold.sql
+++ b/packages/db/migrations/202502010001_billing_scaffold.sql
@@ -1,0 +1,398 @@
+-- Stripe billing scaffold: tables, enums, RLS, and RPC helpers
+
+-- Create enums if they do not already exist
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'billing_tenant_mode') THEN
+    CREATE TYPE billing_tenant_mode AS ENUM ('direct', 'partner_managed');
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'billing_subscription_status') THEN
+    CREATE TYPE billing_subscription_status AS ENUM (
+      'trialing',
+      'active',
+      'incomplete',
+      'incomplete_expired',
+      'past_due',
+      'canceled',
+      'unpaid',
+      'paused'
+    );
+  END IF;
+END
+$$;
+
+CREATE TABLE IF NOT EXISTS billing_prices (
+  stripe_price_id text PRIMARY KEY,
+  product_name text NOT NULL,
+  nickname text,
+  unit_amount integer,
+  currency text NOT NULL,
+  interval text,
+  interval_count integer,
+  is_active boolean NOT NULL DEFAULT true,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS billing_tenants (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_org_id uuid NOT NULL REFERENCES organisations(id) ON DELETE CASCADE,
+  stripe_customer_id text UNIQUE,
+  billing_mode billing_tenant_mode NOT NULL DEFAULT 'direct',
+  partner_org_id uuid REFERENCES organisations(id),
+  default_price_id text REFERENCES billing_prices(stripe_price_id),
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT billing_tenants_tenant_unique UNIQUE (tenant_org_id)
+);
+
+CREATE TABLE IF NOT EXISTS billing_subscriptions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_org_id uuid NOT NULL REFERENCES organisations(id) ON DELETE CASCADE,
+  billing_tenant_id uuid REFERENCES billing_tenants(id) ON DELETE SET NULL,
+  stripe_subscription_id text NOT NULL UNIQUE,
+  status billing_subscription_status NOT NULL,
+  stripe_price_id text REFERENCES billing_prices(stripe_price_id),
+  current_period_start timestamptz,
+  current_period_end timestamptz,
+  cancel_at timestamptz,
+  canceled_at timestamptz,
+  cancel_at_period_end boolean NOT NULL DEFAULT false,
+  collection_method text,
+  latest_invoice_id text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS billing_tenants_tenant_idx ON billing_tenants(tenant_org_id);
+CREATE INDEX IF NOT EXISTS billing_subscriptions_tenant_idx ON billing_subscriptions(tenant_org_id);
+CREATE INDEX IF NOT EXISTS billing_subscriptions_status_idx ON billing_subscriptions(status);
+CREATE INDEX IF NOT EXISTS billing_prices_active_idx ON billing_prices(is_active);
+
+ALTER TABLE billing_prices ENABLE ROW LEVEL SECURITY;
+ALTER TABLE billing_tenants ENABLE ROW LEVEL SECURITY;
+ALTER TABLE billing_subscriptions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "Service role manages billing prices" ON billing_prices
+  FOR ALL USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+CREATE POLICY IF NOT EXISTS "Authenticated read billing prices" ON billing_prices
+  FOR SELECT USING (
+    auth.role() = 'service_role'
+    OR auth.role() = 'authenticated'
+  );
+
+CREATE POLICY IF NOT EXISTS "Service role manages billing tenants" ON billing_tenants
+  FOR ALL USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+CREATE POLICY IF NOT EXISTS "Tenant members read billing tenants" ON billing_tenants
+  FOR SELECT USING (
+    auth.role() = 'service_role'
+    OR public.is_member_of_org(tenant_org_id)
+  );
+
+CREATE POLICY IF NOT EXISTS "Service role manages billing subscriptions" ON billing_subscriptions
+  FOR ALL USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+CREATE POLICY IF NOT EXISTS "Tenant members read billing subscriptions" ON billing_subscriptions
+  FOR SELECT USING (
+    auth.role() = 'service_role'
+    OR public.is_member_of_org(tenant_org_id)
+  );
+
+CREATE OR REPLACE FUNCTION public.rpc_upsert_billing_price(
+  p_stripe_price_id text,
+  p_product_name text,
+  p_nickname text DEFAULT NULL,
+  p_unit_amount integer DEFAULT NULL,
+  p_currency text,
+  p_interval text DEFAULT NULL,
+  p_interval_count integer DEFAULT NULL,
+  p_is_active boolean DEFAULT true,
+  p_metadata jsonb DEFAULT '{}'::jsonb
+)
+RETURNS billing_prices
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_price billing_prices;
+BEGIN
+  IF coalesce(trim(p_stripe_price_id), '') = '' THEN
+    RAISE EXCEPTION 'Stripe price id is required' USING errcode = '23514';
+  END IF;
+
+  INSERT INTO billing_prices AS bp (
+    stripe_price_id,
+    product_name,
+    nickname,
+    unit_amount,
+    currency,
+    interval,
+    interval_count,
+    is_active,
+    metadata,
+    updated_at
+  )
+  VALUES (
+    p_stripe_price_id,
+    p_product_name,
+    NULLIF(p_nickname, ''),
+    p_unit_amount,
+    p_currency,
+    NULLIF(p_interval, ''),
+    p_interval_count,
+    COALESCE(p_is_active, true),
+    COALESCE(p_metadata, '{}'::jsonb),
+    now()
+  )
+  ON CONFLICT (stripe_price_id) DO UPDATE
+    SET product_name = EXCLUDED.product_name,
+        nickname = EXCLUDED.nickname,
+        unit_amount = EXCLUDED.unit_amount,
+        currency = EXCLUDED.currency,
+        interval = EXCLUDED.interval,
+        interval_count = EXCLUDED.interval_count,
+        is_active = EXCLUDED.is_active,
+        metadata = EXCLUDED.metadata,
+        updated_at = now()
+  RETURNING * INTO v_price;
+
+  RETURN v_price;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_upsert_billing_price(
+  text,
+  text,
+  text,
+  integer,
+  text,
+  text,
+  integer,
+  boolean,
+  jsonb
+) TO authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.rpc_upsert_billing_tenant(
+  p_tenant_org_id uuid,
+  p_stripe_customer_id text,
+  p_billing_mode billing_tenant_mode DEFAULT 'direct',
+  p_partner_org_id uuid DEFAULT NULL,
+  p_default_price_id text DEFAULT NULL,
+  p_metadata jsonb DEFAULT '{}'::jsonb
+)
+RETURNS billing_tenants
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_tenant billing_tenants;
+BEGIN
+  IF p_tenant_org_id IS NULL THEN
+    RAISE EXCEPTION 'Tenant organisation id is required' USING errcode = '23514';
+  END IF;
+
+  PERFORM public.assert_tenant_membership(p_tenant_org_id);
+
+  INSERT INTO billing_tenants AS bt (
+    tenant_org_id,
+    stripe_customer_id,
+    billing_mode,
+    partner_org_id,
+    default_price_id,
+    metadata,
+    updated_at
+  )
+  VALUES (
+    p_tenant_org_id,
+    NULLIF(p_stripe_customer_id, ''),
+    COALESCE(p_billing_mode, 'direct'),
+    p_partner_org_id,
+    NULLIF(p_default_price_id, ''),
+    COALESCE(p_metadata, '{}'::jsonb),
+    now()
+  )
+  ON CONFLICT (tenant_org_id) DO UPDATE
+    SET stripe_customer_id = EXCLUDED.stripe_customer_id,
+        billing_mode = EXCLUDED.billing_mode,
+        partner_org_id = EXCLUDED.partner_org_id,
+        default_price_id = EXCLUDED.default_price_id,
+        metadata = EXCLUDED.metadata,
+        updated_at = now()
+  RETURNING * INTO v_tenant;
+
+  RETURN v_tenant;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_upsert_billing_tenant(
+  uuid,
+  text,
+  billing_tenant_mode,
+  uuid,
+  text,
+  jsonb
+) TO authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.rpc_upsert_billing_subscription(
+  p_tenant_org_id uuid,
+  p_billing_tenant_id uuid DEFAULT NULL,
+  p_stripe_subscription_id text,
+  p_status billing_subscription_status,
+  p_stripe_price_id text DEFAULT NULL,
+  p_current_period_start timestamptz DEFAULT NULL,
+  p_current_period_end timestamptz DEFAULT NULL,
+  p_cancel_at timestamptz DEFAULT NULL,
+  p_canceled_at timestamptz DEFAULT NULL,
+  p_cancel_at_period_end boolean DEFAULT false,
+  p_collection_method text DEFAULT NULL,
+  p_latest_invoice_id text DEFAULT NULL,
+  p_metadata jsonb DEFAULT '{}'::jsonb
+)
+RETURNS billing_subscriptions
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_subscription billing_subscriptions;
+  v_billing_tenant_id uuid;
+BEGIN
+  IF p_tenant_org_id IS NULL THEN
+    RAISE EXCEPTION 'Tenant organisation id is required' USING errcode = '23514';
+  END IF;
+
+  IF coalesce(trim(p_stripe_subscription_id), '') = '' THEN
+    RAISE EXCEPTION 'Stripe subscription id is required' USING errcode = '23514';
+  END IF;
+
+  PERFORM public.assert_tenant_membership(p_tenant_org_id);
+
+  IF p_billing_tenant_id IS NOT NULL THEN
+    v_billing_tenant_id := p_billing_tenant_id;
+  ELSE
+    SELECT id
+      INTO v_billing_tenant_id
+    FROM billing_tenants
+    WHERE tenant_org_id = p_tenant_org_id
+    ORDER BY updated_at DESC
+    LIMIT 1;
+  END IF;
+
+  INSERT INTO billing_subscriptions AS bs (
+    tenant_org_id,
+    billing_tenant_id,
+    stripe_subscription_id,
+    status,
+    stripe_price_id,
+    current_period_start,
+    current_period_end,
+    cancel_at,
+    canceled_at,
+    cancel_at_period_end,
+    collection_method,
+    latest_invoice_id,
+    metadata,
+    updated_at
+  )
+  VALUES (
+    p_tenant_org_id,
+    v_billing_tenant_id,
+    p_stripe_subscription_id,
+    p_status,
+    NULLIF(p_stripe_price_id, ''),
+    p_current_period_start,
+    p_current_period_end,
+    p_cancel_at,
+    p_canceled_at,
+    COALESCE(p_cancel_at_period_end, false),
+    NULLIF(p_collection_method, ''),
+    NULLIF(p_latest_invoice_id, ''),
+    COALESCE(p_metadata, '{}'::jsonb),
+    now()
+  )
+  ON CONFLICT (stripe_subscription_id) DO UPDATE
+    SET tenant_org_id = EXCLUDED.tenant_org_id,
+        billing_tenant_id = EXCLUDED.billing_tenant_id,
+        status = EXCLUDED.status,
+        stripe_price_id = EXCLUDED.stripe_price_id,
+        current_period_start = EXCLUDED.current_period_start,
+        current_period_end = EXCLUDED.current_period_end,
+        cancel_at = EXCLUDED.cancel_at,
+        canceled_at = EXCLUDED.canceled_at,
+        cancel_at_period_end = EXCLUDED.cancel_at_period_end,
+        collection_method = EXCLUDED.collection_method,
+        latest_invoice_id = EXCLUDED.latest_invoice_id,
+        metadata = EXCLUDED.metadata,
+        updated_at = now()
+  RETURNING * INTO v_subscription;
+
+  RETURN v_subscription;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_upsert_billing_subscription(
+  uuid,
+  uuid,
+  text,
+  billing_subscription_status,
+  text,
+  timestamptz,
+  timestamptz,
+  timestamptz,
+  timestamptz,
+  boolean,
+  text,
+  text,
+  jsonb
+) TO authenticated, service_role;
+
+CREATE OR REPLACE VIEW billing_subscription_overview AS
+SELECT
+  bt.tenant_org_id,
+  bt.billing_mode,
+  bt.stripe_customer_id,
+  bt.partner_org_id,
+  bt.default_price_id,
+  bt.metadata AS tenant_metadata,
+  bt.updated_at AS tenant_updated_at,
+  bs.stripe_subscription_id,
+  bs.status,
+  bs.stripe_price_id,
+  bs.current_period_start,
+  bs.current_period_end,
+  bs.cancel_at,
+  bs.canceled_at,
+  bs.cancel_at_period_end,
+  bs.collection_method,
+  bs.latest_invoice_id,
+  bs.metadata AS subscription_metadata,
+  bs.updated_at AS subscription_updated_at,
+  bp.product_name,
+  bp.nickname,
+  bp.unit_amount,
+  bp.currency,
+  bp.interval,
+  bp.interval_count,
+  bp.is_active AS price_active,
+  bp.metadata AS price_metadata,
+  bp.updated_at AS price_updated_at
+FROM billing_tenants bt
+LEFT JOIN billing_subscriptions bs ON bs.billing_tenant_id = bt.id
+LEFT JOIN billing_prices bp ON bp.stripe_price_id = COALESCE(bs.stripe_price_id, bt.default_price_id);
+
+GRANT SELECT ON billing_subscription_overview TO authenticated, service_role;

--- a/packages/types/src/supabase.ts
+++ b/packages/types/src/supabase.ts
@@ -222,6 +222,209 @@ export type Database = {
           }
         ];
       };
+      billing_prices: {
+        Row: {
+          stripe_price_id: string;
+          product_name: string;
+          nickname: string | null;
+          unit_amount: number | null;
+          currency: string;
+          interval: string | null;
+          interval_count: number | null;
+          is_active: boolean;
+          metadata: Json;
+          created_at: string | null;
+          updated_at: string | null;
+        };
+        Insert: {
+          stripe_price_id: string;
+          product_name: string;
+          nickname?: string | null;
+          unit_amount?: number | null;
+          currency: string;
+          interval?: string | null;
+          interval_count?: number | null;
+          is_active?: boolean;
+          metadata?: Json;
+          created_at?: string | null;
+          updated_at?: string | null;
+        };
+        Update: {
+          stripe_price_id?: string;
+          product_name?: string;
+          nickname?: string | null;
+          unit_amount?: number | null;
+          currency?: string;
+          interval?: string | null;
+          interval_count?: number | null;
+          is_active?: boolean;
+          metadata?: Json;
+          created_at?: string | null;
+          updated_at?: string | null;
+        };
+        Relationships: [];
+      };
+      billing_tenants: {
+        Row: {
+          id: string;
+          tenant_org_id: string;
+          stripe_customer_id: string | null;
+          billing_mode: "direct" | "partner_managed";
+          partner_org_id: string | null;
+          default_price_id: string | null;
+          metadata: Json;
+          created_at: string | null;
+          updated_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          tenant_org_id: string;
+          stripe_customer_id?: string | null;
+          billing_mode?: "direct" | "partner_managed";
+          partner_org_id?: string | null;
+          default_price_id?: string | null;
+          metadata?: Json;
+          created_at?: string | null;
+          updated_at?: string | null;
+        };
+        Update: {
+          id?: string;
+          tenant_org_id?: string;
+          stripe_customer_id?: string | null;
+          billing_mode?: "direct" | "partner_managed";
+          partner_org_id?: string | null;
+          default_price_id?: string | null;
+          metadata?: Json;
+          created_at?: string | null;
+          updated_at?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "billing_tenants_default_price_id_fkey";
+            columns: ["default_price_id"];
+            isOneToOne: false;
+            referencedRelation: "billing_prices";
+            referencedColumns: ["stripe_price_id"];
+          },
+          {
+            foreignKeyName: "billing_tenants_partner_org_id_fkey";
+            columns: ["partner_org_id"];
+            isOneToOne: false;
+            referencedRelation: "organisations";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "billing_tenants_tenant_org_id_fkey";
+            columns: ["tenant_org_id"];
+            isOneToOne: false;
+            referencedRelation: "organisations";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+      billing_subscriptions: {
+        Row: {
+          id: string;
+          tenant_org_id: string;
+          billing_tenant_id: string | null;
+          stripe_subscription_id: string;
+          status:
+            | "trialing"
+            | "active"
+            | "incomplete"
+            | "incomplete_expired"
+            | "past_due"
+            | "canceled"
+            | "unpaid"
+            | "paused";
+          stripe_price_id: string | null;
+          current_period_start: string | null;
+          current_period_end: string | null;
+          cancel_at: string | null;
+          canceled_at: string | null;
+          cancel_at_period_end: boolean;
+          collection_method: string | null;
+          latest_invoice_id: string | null;
+          metadata: Json;
+          created_at: string | null;
+          updated_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          tenant_org_id: string;
+          billing_tenant_id?: string | null;
+          stripe_subscription_id: string;
+          status?:
+            | "trialing"
+            | "active"
+            | "incomplete"
+            | "incomplete_expired"
+            | "past_due"
+            | "canceled"
+            | "unpaid"
+            | "paused";
+          stripe_price_id?: string | null;
+          current_period_start?: string | null;
+          current_period_end?: string | null;
+          cancel_at?: string | null;
+          canceled_at?: string | null;
+          cancel_at_period_end?: boolean;
+          collection_method?: string | null;
+          latest_invoice_id?: string | null;
+          metadata?: Json;
+          created_at?: string | null;
+          updated_at?: string | null;
+        };
+        Update: {
+          id?: string;
+          tenant_org_id?: string;
+          billing_tenant_id?: string | null;
+          stripe_subscription_id?: string;
+          status?:
+            | "trialing"
+            | "active"
+            | "incomplete"
+            | "incomplete_expired"
+            | "past_due"
+            | "canceled"
+            | "unpaid"
+            | "paused";
+          stripe_price_id?: string | null;
+          current_period_start?: string | null;
+          current_period_end?: string | null;
+          cancel_at?: string | null;
+          canceled_at?: string | null;
+          cancel_at_period_end?: boolean;
+          collection_method?: string | null;
+          latest_invoice_id?: string | null;
+          metadata?: Json;
+          created_at?: string | null;
+          updated_at?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "billing_subscriptions_billing_tenant_id_fkey";
+            columns: ["billing_tenant_id"];
+            isOneToOne: false;
+            referencedRelation: "billing_tenants";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "billing_subscriptions_stripe_price_id_fkey";
+            columns: ["stripe_price_id"];
+            isOneToOne: false;
+            referencedRelation: "billing_prices";
+            referencedColumns: ["stripe_price_id"];
+          },
+          {
+            foreignKeyName: "billing_subscriptions_tenant_org_id_fkey";
+            columns: ["tenant_org_id"];
+            isOneToOne: false;
+            referencedRelation: "organisations";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       engagements: {
         Row: {
           id: string;
@@ -1500,7 +1703,48 @@ export type Database = {
       };
     };
     Views: {
-      [_ in never]: never;
+      billing_subscription_overview: {
+        Row: {
+          tenant_org_id: string;
+          billing_mode: "direct" | "partner_managed";
+          stripe_customer_id: string | null;
+          partner_org_id: string | null;
+          default_price_id: string | null;
+          tenant_metadata: Json;
+          tenant_updated_at: string | null;
+          stripe_subscription_id: string | null;
+          status:
+            | "trialing"
+            | "active"
+            | "incomplete"
+            | "incomplete_expired"
+            | "past_due"
+            | "canceled"
+            | "unpaid"
+            | "paused"
+            | null;
+          stripe_price_id: string | null;
+          current_period_start: string | null;
+          current_period_end: string | null;
+          cancel_at: string | null;
+          canceled_at: string | null;
+          cancel_at_period_end: boolean | null;
+          collection_method: string | null;
+          latest_invoice_id: string | null;
+          subscription_metadata: Json | null;
+          subscription_updated_at: string | null;
+          product_name: string | null;
+          nickname: string | null;
+          unit_amount: number | null;
+          currency: string | null;
+          interval: string | null;
+          interval_count: number | null;
+          price_active: boolean | null;
+          price_metadata: Json | null;
+          price_updated_at: string | null;
+        };
+        Relationships: [];
+      };
     };
     Functions: {
       assert_tenant_membership: {
@@ -1554,6 +1798,57 @@ export type Database = {
           p_tenant_org_id: string;
         };
         Returns: Database["public"]["Tables"]["tenant_branding"]["Row"] | null;
+      };
+      rpc_upsert_billing_price: {
+        Args: {
+          p_stripe_price_id: string;
+          p_product_name: string;
+          p_nickname?: string | null;
+          p_unit_amount?: number | null;
+          p_currency: string;
+          p_interval?: string | null;
+          p_interval_count?: number | null;
+          p_is_active?: boolean;
+          p_metadata?: Json;
+        };
+        Returns: Database["public"]["Tables"]["billing_prices"]["Row"];
+      };
+      rpc_upsert_billing_subscription: {
+        Args: {
+          p_tenant_org_id: string;
+          p_billing_tenant_id?: string | null;
+          p_stripe_subscription_id: string;
+          p_status:
+            | "trialing"
+            | "active"
+            | "incomplete"
+            | "incomplete_expired"
+            | "past_due"
+            | "canceled"
+            | "unpaid"
+            | "paused";
+          p_stripe_price_id?: string | null;
+          p_current_period_start?: string | null;
+          p_current_period_end?: string | null;
+          p_cancel_at?: string | null;
+          p_canceled_at?: string | null;
+          p_cancel_at_period_end?: boolean;
+          p_collection_method?: string | null;
+          p_latest_invoice_id?: string | null;
+          p_metadata?: Json;
+        };
+        Returns: Database["public"]["Tables"]["billing_subscriptions"]["Row"];
+      };
+      rpc_upsert_billing_tenant: {
+        Args: {
+          p_tenant_org_id: string;
+          p_stripe_customer_id?: string | null;
+          p_billing_mode?: "direct" | "partner_managed";
+          p_partner_org_id?: string | null;
+          p_default_price_id?: string | null;
+          p_metadata?: Json;
+        };
+        Returns: Database["public"]["Tables"]["billing_tenants"]["Row"];
       };
       rpc_mark_tenant_domain_verified: {
         Args: {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -8,12 +8,14 @@
     "./date": "./src/date.ts",
     "./dsr": "./src/dsr.ts",
     "./ics": "./src/ics.ts",
+    "./billing": "./src/billing.ts",
     "./supabase-service": "./src/supabase-service.ts",
     "./security-headers": "./src/security-headers.ts",
     "./telemetry": "./src/telemetry.ts",
     "./index": "./src/index.ts"
   },
   "dependencies": {
-    "@opentelemetry/api": "^1.9.0"
+    "@opentelemetry/api": "^1.9.0",
+    "stripe": "^14.25.0"
   }
 }

--- a/packages/utils/src/billing.ts
+++ b/packages/utils/src/billing.ts
@@ -1,0 +1,135 @@
+import Stripe from "stripe";
+
+export class StripeConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "StripeConfigurationError";
+  }
+}
+
+export class StripeWebhookVerificationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "StripeWebhookVerificationError";
+  }
+}
+
+let stripeClient: Stripe | null = null;
+
+function resolveStripeSecretKey(): string {
+  const secret = process.env.STRIPE_SECRET_KEY;
+  if (!secret) {
+    throw new StripeConfigurationError(
+      "STRIPE_SECRET_KEY must be configured to perform billing operations."
+    );
+  }
+  return secret;
+}
+
+function resolveWebhookSecret(): string {
+  const secret = process.env.STRIPE_WEBHOOK_SECRET;
+  if (!secret) {
+    throw new StripeConfigurationError(
+      "STRIPE_WEBHOOK_SECRET must be configured to verify incoming Stripe events."
+    );
+  }
+  return secret;
+}
+
+export function getStripeClient(): Stripe {
+  if (!stripeClient) {
+    const secretKey = resolveStripeSecretKey();
+    stripeClient = new Stripe(secretKey, {
+      apiVersion: "2024-06-20"
+    });
+  }
+  return stripeClient;
+}
+
+export function verifyStripeWebhookSignature(payload: string, signature: string | null): Stripe.Event {
+  if (!signature) {
+    throw new StripeWebhookVerificationError("Missing Stripe-Signature header");
+  }
+  const webhookSecret = resolveWebhookSecret();
+  try {
+    return Stripe.webhooks.constructEvent(payload, signature, webhookSecret);
+  } catch (error) {
+    throw new StripeWebhookVerificationError(
+      `Invalid Stripe signature: ${(error as Error).message}`
+    );
+  }
+}
+
+export interface EnsureStripeCustomerParams {
+  stripeCustomerId?: string | null;
+  email?: string | null;
+  name?: string | null;
+  tenantOrgId?: string;
+  billingMode?: string | null;
+  partnerOrgId?: string | null;
+  defaultPriceId?: string | null;
+  metadata?: Stripe.MetadataParam;
+}
+
+export async function ensureStripeCustomer({
+  stripeCustomerId,
+  email,
+  name,
+  tenantOrgId,
+  billingMode,
+  partnerOrgId,
+  defaultPriceId,
+  metadata
+}: EnsureStripeCustomerParams): Promise<Stripe.Customer> {
+  const stripe = getStripeClient();
+  const mergedMetadata: Stripe.MetadataParam = {
+    ...(metadata ?? {}),
+    ...(tenantOrgId ? { tenant_org_id: tenantOrgId } : {}),
+    ...(billingMode ? { billing_mode: billingMode } : {}),
+    ...(partnerOrgId ? { partner_org_id: partnerOrgId } : {}),
+    ...(defaultPriceId ? { default_price_id: defaultPriceId } : {})
+  };
+
+  if (stripeCustomerId) {
+    return stripe.customers.update(stripeCustomerId, {
+      email: email ?? undefined,
+      name: name ?? undefined,
+      metadata: mergedMetadata
+    });
+  }
+
+  return stripe.customers.create({
+    email: email ?? undefined,
+    name: name ?? undefined,
+    metadata: mergedMetadata
+  });
+}
+
+export interface CreateStripeSubscriptionParams {
+  customerId: string;
+  priceId: string;
+  trialPeriodDays?: number;
+  collectionMethod?: "charge_automatically" | "send_invoice";
+  metadata?: Stripe.MetadataParam;
+}
+
+export async function createStripeSubscription({
+  customerId,
+  priceId,
+  trialPeriodDays,
+  collectionMethod,
+  metadata
+}: CreateStripeSubscriptionParams): Promise<Stripe.Subscription> {
+  const stripe = getStripeClient();
+  return stripe.subscriptions.create({
+    customer: customerId,
+    items: [
+      {
+        price: priceId
+      }
+    ],
+    trial_period_days: trialPeriodDays,
+    collection_method: collectionMethod,
+    metadata
+  });
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -2,6 +2,7 @@ export * from "./date.js";
 export * from "./ics.js";
 export * from "./i18n.js";
 export * from "./dsr.js";
+export * from "./billing.js";
 export * from "./supabase-service.js";
 export * from "./security-headers.js";
 export * from "./telemetry.js";


### PR DESCRIPTION
## Summary
- add Supabase billing tables, policies, helper RPCs, and a subscription overview view for RLS access
- introduce Stripe webhook and provisioning API routes that validate signatures and synchronize Supabase billing state
- provide shared Stripe billing utilities plus a tenant billing page, translations, and home navigation entry in the portal

## Testing
- ⚠️ `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=fake pnpm --filter @airnub/portal dev -- --port 3101` *(fails: `next` binary missing in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68e00eddce20832481f181bdbb1fe681