### PR TITLE
Add audit logging to tenant branding and domain RPCs

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -6,6 +6,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "tsx --test src/app/api/orchestration/webhook/route.test.ts src/app/api/partner-admin/branding/route.test.ts src/app/api/partner-admin/domains/route.test.ts src/components/__tests__/tenant-overlay-builder.test.ts",
     "test:a11y": "cypress run --e2e --spec cypress/e2e/accessibility.cy.ts",
     "test:pa11y": "pa11y-ci ../../pa11yci.json"
   },

--- a/apps/portal/src/app/api/partner-admin/branding/route.test.ts
+++ b/apps/portal/src/app/api/partner-admin/branding/route.test.ts
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import Module from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import test from "node:test";
+
+async function withBrandingRoute<T>(callback: (route: typeof import("./route")) => Promise<T>) {
+  const tempRoot = mkdtempSync(join(tmpdir(), "branding-route-stub-"));
+  const nextRoot = join(tempRoot, "next");
+  const supabaseRoot = join(tempRoot, "@supabase", "ssr");
+  const previousNodePath = process.env.NODE_PATH;
+  try {
+    mkdirSync(nextRoot, { recursive: true });
+    mkdirSync(supabaseRoot, { recursive: true });
+    const packageJson = {
+      name: "next",
+      type: "module",
+      exports: {
+        "./server": "./server.js",
+        "./headers": "./headers.js"
+      }
+    } as const;
+    writeFileSync(join(nextRoot, "package.json"), JSON.stringify(packageJson));
+    writeFileSync(
+      join(nextRoot, "server.js"),
+      "export class NextResponse extends Response {\n  static json(body, init = {}) {\n    const headers = new Headers(init.headers ?? {});\n    if (!headers.has(\"content-type\")) {\n      headers.set(\"content-type\", \"application/json\");\n    }\n    return new Response(typeof body === 'string' ? body : JSON.stringify(body), { status: init.status ?? 200, headers });\n  }\n}\n"
+    );
+    writeFileSync(
+      join(nextRoot, "headers.js"),
+      "const store = new Map();\nexport function cookies() {\n  return {\n    get(name) {\n      return store.has(name) ? { value: store.get(name) } : undefined;\n    },\n    set(name, value) {\n      store.set(name, value);\n    },\n    remove(name) {\n      store.delete(name);\n    }\n  };\n}\n"
+    );
+
+    const supabasePackage = {
+      name: "@supabase/ssr",
+      type: "module",
+      exports: "./index.js"
+    } as const;
+    writeFileSync(join(supabaseRoot, "package.json"), JSON.stringify(supabasePackage));
+    writeFileSync(
+      join(supabaseRoot, "index.js"),
+      "export function createServerClient() {\n  return { rpc() { throw new Error('not implemented in tests'); } };\n}\n"
+    );
+
+    process.env.NODE_PATH = tempRoot + (previousNodePath ? `:${previousNodePath}` : "");
+    Module._initPaths();
+
+    const route = await import(pathToFileURL(join(process.cwd(), "src/app/api/partner-admin/branding/route.ts")).toString());
+    return await callback(route);
+  } finally {
+    process.env.NODE_PATH = previousNodePath;
+    Module._initPaths();
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+const tenantBrandingStub = {
+  tenantOrgId: "tenant-123",
+  domain: "tenant.example.com",
+  tokens: {},
+  logoUrl: null,
+  faviconUrl: null,
+  typography: null,
+  pdfHeader: null,
+  pdfFooter: null,
+  updatedAt: null
+} as const;
+
+test("POST upserts branding and returns audit metadata", async () => {
+  await withBrandingRoute(async ({ createBrandingRoute }) => {
+    const rpcCalls: Array<{ name: string; params: Record<string, unknown> }> = [];
+
+    const supabase = {
+      async rpc(name: string, params: Record<string, unknown>) {
+        rpcCalls.push({ name, params });
+        return {
+          data: {
+            branding: {
+              tenant_org_id: tenantBrandingStub.tenantOrgId,
+              tokens: { theme: "custom" },
+              logo_url: "https://cdn.example.com/logo.png",
+              favicon_url: null,
+              typography: {},
+              pdf_header: {},
+              pdf_footer: {}
+            },
+            audit_entry: {
+              audit_id: "audit-1",
+              action: "tenant_branding_update",
+              reason_code: "tenant_branding_update"
+            }
+          },
+          error: null
+        } as const;
+      }
+    };
+
+    const route = createBrandingRoute({
+      getSupabaseClient: () => supabase,
+      resolveTenantBranding: async (host: string | null | undefined) => {
+        assert.equal(host, "tenant.example.com");
+        return tenantBrandingStub;
+      }
+    });
+
+    const request = new Request("http://localhost/api/partner-admin/branding", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        host: "tenant.example.com"
+      },
+      body: JSON.stringify({ tokens: { theme: "custom" } })
+    });
+
+    const response = await route.POST(request);
+    assert.equal(response.status, 200);
+    const json = (await response.json()) as Record<string, unknown>;
+
+    assert.equal(json.ok, true);
+    assert.deepEqual(json.branding, {
+      tenant_org_id: tenantBrandingStub.tenantOrgId,
+      tokens: { theme: "custom" },
+      logo_url: "https://cdn.example.com/logo.png",
+      favicon_url: null,
+      typography: {},
+      pdf_header: {},
+      pdf_footer: {}
+    });
+    assert.deepEqual(json.audit, {
+      audit_id: "audit-1",
+      action: "tenant_branding_update",
+      reason_code: "tenant_branding_update"
+    });
+
+    assert.equal(rpcCalls.length, 1);
+    assert.equal(rpcCalls[0]?.name, "rpc_upsert_tenant_branding");
+    assert.equal(rpcCalls[0]?.params?.p_tenant_org_id, tenantBrandingStub.tenantOrgId);
+  });
+});
+
+test("POST surfaces audit failures", async () => {
+  await withBrandingRoute(async ({ createBrandingRoute }) => {
+    const route = createBrandingRoute({
+      getSupabaseClient: () => ({
+        async rpc() {
+          return {
+            data: null,
+            error: {
+              message: "Audit write failed",
+              details: "audit ledger append refused",
+              code: "40001"
+            }
+          } as const;
+        }
+      }),
+      resolveTenantBranding: async () => tenantBrandingStub
+    });
+
+    const request = new Request("http://localhost/api/partner-admin/branding", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        host: "tenant.example.com"
+      },
+      body: JSON.stringify({ tokens: {} })
+    });
+
+    const response = await route.POST(request);
+    assert.equal(response.status, 400);
+    const json = (await response.json()) as Record<string, unknown>;
+    assert.equal(json.ok, false);
+    assert.equal(json.error, "audit ledger append refused");
+  });
+});

--- a/apps/portal/src/app/api/partner-admin/domains/route.test.ts
+++ b/apps/portal/src/app/api/partner-admin/domains/route.test.ts
@@ -1,0 +1,282 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import Module from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import test from "node:test";
+
+async function withDomainsRoute<T>(callback: (route: typeof import("./route")) => Promise<T>) {
+  const tempRoot = mkdtempSync(join(tmpdir(), "domains-route-stub-"));
+  const nextRoot = join(tempRoot, "next");
+  const supabaseRoot = join(tempRoot, "@supabase", "ssr");
+  const previousNodePath = process.env.NODE_PATH;
+  try {
+    mkdirSync(nextRoot, { recursive: true });
+    mkdirSync(supabaseRoot, { recursive: true });
+    const packageJson = {
+      name: "next",
+      type: "module",
+      exports: {
+        "./server": "./server.js",
+        "./headers": "./headers.js"
+      }
+    } as const;
+    writeFileSync(join(nextRoot, "package.json"), JSON.stringify(packageJson));
+    writeFileSync(
+      join(nextRoot, "server.js"),
+      "export class NextResponse extends Response {\n  static json(body, init = {}) {\n    const headers = new Headers(init.headers ?? {});\n    if (!headers.has(\"content-type\")) {\n      headers.set(\"content-type\", \"application/json\");\n    }\n    return new Response(typeof body === 'string' ? body : JSON.stringify(body), { status: init.status ?? 200, headers });\n  }\n}\n"
+    );
+    writeFileSync(
+      join(nextRoot, "headers.js"),
+      "const store = new Map();\nexport function cookies() {\n  return {\n    get(name) {\n      return store.has(name) ? { value: store.get(name) } : undefined;\n    },\n    set(name, value) {\n      store.set(name, value);\n    },\n    remove(name) {\n      store.delete(name);\n    }\n  };\n}\n"
+    );
+
+    const supabasePackage = {
+      name: "@supabase/ssr",
+      type: "module",
+      exports: "./index.js"
+    } as const;
+    writeFileSync(join(supabaseRoot, "package.json"), JSON.stringify(supabasePackage));
+    writeFileSync(
+      join(supabaseRoot, "index.js"),
+      "export function createServerClient() {\n  return { rpc() { throw new Error('not implemented in tests'); } };\n}\n"
+    );
+
+    process.env.NODE_PATH = tempRoot + (previousNodePath ? `:${previousNodePath}` : "");
+    Module._initPaths();
+
+    const route = await import(pathToFileURL(join(process.cwd(), "src/app/api/partner-admin/domains/route.ts")).toString());
+    return await callback(route);
+  } finally {
+    process.env.NODE_PATH = previousNodePath;
+    Module._initPaths();
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+const tenantBrandingStub = {
+  tenantOrgId: "tenant-123",
+  domain: "tenant.example.com",
+  tokens: {},
+  logoUrl: null,
+  faviconUrl: null,
+  typography: null,
+  pdfHeader: null,
+  pdfFooter: null,
+  updatedAt: null
+} as const;
+
+test("POST claims domain and emits audit metadata", async () => {
+  await withDomainsRoute(async ({ createDomainRoutes }) => {
+    const rpcCalls: Array<{ name: string; params: Record<string, unknown> }> = [];
+
+    const supabase = {
+      async rpc(name: string, params: Record<string, unknown>) {
+        rpcCalls.push({ name, params });
+        return {
+          data: {
+            domain: {
+              id: "domain-1",
+              tenant_org_id: tenantBrandingStub.tenantOrgId,
+              domain: "tenant.example.com",
+              is_primary: false,
+              cert_status: "pending",
+              verified_at: null
+            },
+            audit_entry: {
+              audit_id: "audit-1",
+              action: "tenant_domain_claim",
+              reason_code: "tenant_domain_claim"
+            }
+          },
+          error: null
+        } as const;
+      }
+    };
+
+    const routes = createDomainRoutes({
+      getSupabaseClient: () => supabase,
+      resolveTenantBranding: async (host: string | null | undefined) => {
+        assert.equal(host, "tenant.example.com");
+        return tenantBrandingStub;
+      }
+    });
+
+    const request = new Request("http://localhost/api/partner-admin/domains", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        host: "tenant.example.com"
+      },
+      body: JSON.stringify({ domain: "tenant.example.com" })
+    });
+
+    const response = await routes.POST(request);
+    assert.equal(response.status, 200);
+    const json = (await response.json()) as Record<string, unknown>;
+
+    assert.equal(json.ok, true);
+    assert.deepEqual(json.domain, {
+      id: "domain-1",
+      tenant_org_id: tenantBrandingStub.tenantOrgId,
+      domain: "tenant.example.com",
+      is_primary: false,
+      cert_status: "pending",
+      verified_at: null
+    });
+    assert.deepEqual(json.audit, {
+      audit_id: "audit-1",
+      action: "tenant_domain_claim",
+      reason_code: "tenant_domain_claim"
+    });
+
+    assert.equal(rpcCalls.length, 1);
+    assert.equal(rpcCalls[0]?.name, "rpc_upsert_tenant_domain");
+    assert.equal(rpcCalls[0]?.params?.p_domain, "tenant.example.com");
+  });
+});
+
+test("PATCH verifies domain and returns audit entry", async () => {
+  await withDomainsRoute(async ({ createDomainRoutes }) => {
+    const supabase = {
+      async rpc(name: string, params: Record<string, unknown>) {
+        if (name === "rpc_mark_tenant_domain_verified") {
+          return {
+            data: {
+              domain: {
+                id: params.p_domain_id,
+                tenant_org_id: tenantBrandingStub.tenantOrgId,
+                domain: "tenant.example.com",
+                is_primary: false,
+                cert_status: "issued",
+                verified_at: params.p_verified_at
+              },
+              audit_entry: {
+                audit_id: "audit-verify",
+                action: "tenant_domain_verify",
+                reason_code: "tenant_domain_verify"
+              }
+            },
+            error: null
+          } as const;
+        }
+
+        throw new Error(`Unexpected rpc call: ${name}`);
+      }
+    };
+
+    const routes = createDomainRoutes({
+      getSupabaseClient: () => supabase,
+      resolveTenantBranding: async () => tenantBrandingStub
+    });
+
+    const request = new Request("http://localhost/api/partner-admin/domains", {
+      method: "PATCH",
+      headers: {
+        "content-type": "application/json",
+        host: "tenant.example.com"
+      },
+      body: JSON.stringify({
+        action: "verify",
+        domainId: "domain-1",
+        certStatus: "issued",
+        verifiedAt: "2025-02-14T00:00:00.000Z"
+      })
+    });
+
+    const response = await routes.PATCH(request);
+    assert.equal(response.status, 200);
+    const json = (await response.json()) as Record<string, unknown>;
+
+    assert.equal(json.ok, true);
+    assert.deepEqual(json.audit, {
+      audit_id: "audit-verify",
+      action: "tenant_domain_verify",
+      reason_code: "tenant_domain_verify"
+    });
+  });
+});
+
+test("DELETE reports audit metadata", async () => {
+  await withDomainsRoute(async ({ createDomainRoutes }) => {
+    const supabase = {
+      async rpc(name: string) {
+        if (name === "rpc_delete_tenant_domain") {
+          return {
+            data: {
+              removed: true,
+              audit_entry: {
+                audit_id: "audit-delete",
+                action: "tenant_domain_delete",
+                reason_code: "tenant_domain_delete"
+              }
+            },
+            error: null
+          } as const;
+        }
+
+        throw new Error(`Unexpected rpc call: ${name}`);
+      }
+    };
+
+    const routes = createDomainRoutes({
+      getSupabaseClient: () => supabase,
+      resolveTenantBranding: async () => tenantBrandingStub
+    });
+
+    const request = new Request("http://localhost/api/partner-admin/domains?id=domain-1", {
+      method: "DELETE",
+      headers: {
+        host: "tenant.example.com"
+      }
+    });
+
+    const response = await routes.DELETE(request);
+    assert.equal(response.status, 200);
+    const json = (await response.json()) as Record<string, unknown>;
+
+    assert.equal(json.ok, true);
+    assert.equal(json.removed, true);
+    assert.deepEqual(json.audit, {
+      audit_id: "audit-delete",
+      action: "tenant_domain_delete",
+      reason_code: "tenant_domain_delete"
+    });
+  });
+});
+
+test("POST surfaces audit failures", async () => {
+  await withDomainsRoute(async ({ createDomainRoutes }) => {
+    const routes = createDomainRoutes({
+      getSupabaseClient: () => ({
+        async rpc() {
+          return {
+            data: null,
+            error: {
+              message: "Audit write failed",
+              details: "audit ledger append refused",
+              code: "40001"
+            }
+          } as const;
+        }
+      }),
+      resolveTenantBranding: async () => tenantBrandingStub
+    });
+
+    const request = new Request("http://localhost/api/partner-admin/domains", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        host: "tenant.example.com"
+      },
+      body: JSON.stringify({ domain: "tenant.example.com" })
+    });
+
+    const response = await routes.POST(request);
+    assert.equal(response.status, 400);
+    const json = (await response.json()) as Record<string, unknown>;
+    assert.equal(json.ok, false);
+    assert.equal(json.error, "audit ledger append refused");
+  });
+});

--- a/apps/portal/src/app/api/partner-admin/domains/route.ts
+++ b/apps/portal/src/app/api/partner-admin/domains/route.ts
@@ -18,143 +18,182 @@ type DomainUpdatePayload = {
   verifiedAt?: string | null;
 };
 
-export async function POST(request: Request) {
-  let payload: DomainCreatePayload;
+type DomainRouteDependencies = {
+  getSupabaseClient: typeof getSupabaseClient;
+  resolveTenantBranding: typeof resolveTenantBranding;
+};
 
-  try {
-    payload = (await request.json()) as DomainCreatePayload;
-  } catch {
-    return NextResponse.json({ ok: false, error: "Invalid JSON payload" }, { status: 400 });
-  }
-
-  if (!payload.domain) {
-    return NextResponse.json({ ok: false, error: "Domain is required" }, { status: 400 });
-  }
-
-  const host = request.headers.get("host");
-  const tenantBranding = await resolveTenantBranding(host);
-
-  try {
-    const supabase = getSupabaseClient();
-    const { data, error } = await supabase.rpc("rpc_upsert_tenant_domain", {
-      p_tenant_org_id: tenantBranding.tenantOrgId,
-      p_domain: payload.domain,
-      p_is_primary: payload.isPrimary ?? false
-    });
-
-    if (error) {
-      return NextResponse.json(
-        { ok: false, error: error.message },
-        { status: error.code === "42501" ? 403 : 400 }
-      );
-    }
-
-    return NextResponse.json({ ok: true, domain: data }, { status: 200 });
-  } catch (error) {
-    if (error instanceof SupabaseConfigurationError) {
-      return NextResponse.json({ ok: false, error: error.message }, { status: 503 });
-    }
-    return NextResponse.json({ ok: false, error: (error as Error).message }, { status: 500 });
-  }
+function formatRpcError(error: { message: string; code?: string; details?: string | null }) {
+  const message = error.details && error.details.trim().length > 0 ? error.details : error.message;
+  return NextResponse.json(
+    { ok: false, error: message },
+    { status: error.code === "42501" ? 403 : 400 }
+  );
 }
 
-export async function PATCH(request: Request) {
-  let payload: DomainUpdatePayload;
+function extractRpcResult(data: unknown) {
+  const payload = (data ?? {}) as Record<string, unknown>;
+  return {
+    domain: payload.domain ?? null,
+    audit: payload.audit_entry ?? null,
+    removed: payload.removed ?? null
+  };
+}
 
-  try {
-    payload = (await request.json()) as DomainUpdatePayload;
-  } catch {
-    return NextResponse.json({ ok: false, error: "Invalid JSON payload" }, { status: 400 });
-  }
+export function createDomainRoutes({
+  getSupabaseClient: getClient,
+  resolveTenantBranding: resolveBranding
+}: DomainRouteDependencies) {
+  return {
+    async POST(request: Request) {
+      let payload: DomainCreatePayload;
 
-  const host = request.headers.get("host");
-  const tenantBranding = await resolveTenantBranding(host);
-
-  try {
-    const supabase = getSupabaseClient();
-
-    if (payload.action === "verify" || payload.action === "updateStatus") {
-      if (!payload.domainId) {
-        return NextResponse.json({ ok: false, error: "domainId is required" }, { status: 400 });
+      try {
+        payload = (await request.json()) as DomainCreatePayload;
+      } catch {
+        return NextResponse.json({ ok: false, error: "Invalid JSON payload" }, { status: 400 });
       }
 
-      const { data, error } = await supabase.rpc("rpc_mark_tenant_domain_verified", {
-        p_domain_id: payload.domainId,
-        p_cert_status: payload.certStatus ?? "issued",
-        p_verified_at: payload.verifiedAt ?? new Date().toISOString()
-      });
-
-      if (error) {
-        return NextResponse.json(
-          { ok: false, error: error.message },
-          { status: error.code === "42501" ? 403 : 400 }
-        );
-      }
-
-      return NextResponse.json({ ok: true, domain: data }, { status: 200 });
-    }
-
-    if (payload.action === "setPrimary") {
       if (!payload.domain) {
         return NextResponse.json({ ok: false, error: "Domain is required" }, { status: 400 });
       }
 
-      const { data, error } = await supabase.rpc("rpc_upsert_tenant_domain", {
-        p_tenant_org_id: tenantBranding.tenantOrgId,
-        p_domain: payload.domain,
-        p_is_primary: true
-      });
+      const host = request.headers.get("host");
+      const tenantBranding = await resolveBranding(host);
 
-      if (error) {
-        return NextResponse.json(
-          { ok: false, error: error.message },
-          { status: error.code === "42501" ? 403 : 400 }
-        );
+      try {
+        const supabase = getClient();
+        const { data, error } = await supabase.rpc("rpc_upsert_tenant_domain", {
+          p_tenant_org_id: tenantBranding.tenantOrgId,
+          p_domain: payload.domain,
+          p_is_primary: payload.isPrimary ?? false
+        });
+
+        if (error) {
+          return formatRpcError(error);
+        }
+
+        const result = extractRpcResult(data);
+
+        return NextResponse.json({ ok: true, domain: result.domain, audit: result.audit }, { status: 200 });
+      } catch (error) {
+        if (error instanceof SupabaseConfigurationError) {
+          return NextResponse.json({ ok: false, error: error.message }, { status: 503 });
+        }
+        return NextResponse.json({ ok: false, error: (error as Error).message }, { status: 500 });
+      }
+    },
+
+    async PATCH(request: Request) {
+      let payload: DomainUpdatePayload;
+
+      try {
+        payload = (await request.json()) as DomainUpdatePayload;
+      } catch {
+        return NextResponse.json({ ok: false, error: "Invalid JSON payload" }, { status: 400 });
       }
 
-      return NextResponse.json({ ok: true, domain: data }, { status: 200 });
-    }
+      const host = request.headers.get("host");
+      const tenantBranding = await resolveBranding(host);
 
-    return NextResponse.json({ ok: false, error: "Unsupported action" }, { status: 400 });
-  } catch (error) {
-    if (error instanceof SupabaseConfigurationError) {
-      return NextResponse.json({ ok: false, error: error.message }, { status: 503 });
+      try {
+        const supabase = getClient();
+
+        if (payload.action === "verify" || payload.action === "updateStatus") {
+          if (!payload.domainId) {
+            return NextResponse.json({ ok: false, error: "domainId is required" }, { status: 400 });
+          }
+
+          const { data, error } = await supabase.rpc("rpc_mark_tenant_domain_verified", {
+            p_domain_id: payload.domainId,
+            p_cert_status: payload.certStatus ?? "issued",
+            p_verified_at: payload.verifiedAt ?? new Date().toISOString()
+          });
+
+          if (error) {
+            return formatRpcError(error);
+          }
+
+          const result = extractRpcResult(data);
+
+          return NextResponse.json({ ok: true, domain: result.domain, audit: result.audit }, { status: 200 });
+        }
+
+        if (payload.action === "setPrimary") {
+          if (!payload.domain) {
+            return NextResponse.json({ ok: false, error: "Domain is required" }, { status: 400 });
+          }
+
+          const { data, error } = await supabase.rpc("rpc_upsert_tenant_domain", {
+            p_tenant_org_id: tenantBranding.tenantOrgId,
+            p_domain: payload.domain,
+            p_is_primary: true
+          });
+
+          if (error) {
+            return formatRpcError(error);
+          }
+
+          const result = extractRpcResult(data);
+
+          return NextResponse.json({ ok: true, domain: result.domain, audit: result.audit }, { status: 200 });
+        }
+
+        return NextResponse.json({ ok: false, error: "Unsupported action" }, { status: 400 });
+      } catch (error) {
+        if (error instanceof SupabaseConfigurationError) {
+          return NextResponse.json({ ok: false, error: error.message }, { status: 503 });
+        }
+        return NextResponse.json({ ok: false, error: (error as Error).message }, { status: 500 });
+      }
+    },
+
+    async DELETE(request: Request) {
+      const { searchParams } = new URL(request.url);
+      const domainId = searchParams.get("id");
+
+      if (!domainId) {
+        return NextResponse.json({ ok: false, error: "Domain id is required" }, { status: 400 });
+      }
+
+      const host = request.headers.get("host");
+      await resolveBranding(host);
+
+      try {
+        const supabase = getClient();
+        const { data, error } = await supabase.rpc("rpc_delete_tenant_domain", {
+          p_domain_id: domainId
+        });
+
+        if (error) {
+          return formatRpcError(error);
+        }
+
+        const result = extractRpcResult(data);
+
+        return NextResponse.json(
+          { ok: true, removed: Boolean(result.removed), audit: result.audit },
+          { status: 200 }
+        );
+      } catch (error) {
+        if (error instanceof SupabaseConfigurationError) {
+          return NextResponse.json({ ok: false, error: error.message }, { status: 503 });
+        }
+        return NextResponse.json({ ok: false, error: (error as Error).message }, { status: 500 });
+      }
     }
-    return NextResponse.json({ ok: false, error: (error as Error).message }, { status: 500 });
-  }
+  };
 }
 
-export async function DELETE(request: Request) {
-  const { searchParams } = new URL(request.url);
-  const domainId = searchParams.get("id");
+const routes = createDomainRoutes({
+  getSupabaseClient,
+  resolveTenantBranding
+});
 
-  if (!domainId) {
-    return NextResponse.json({ ok: false, error: "Domain id is required" }, { status: 400 });
-  }
-
-  const host = request.headers.get("host");
-  const tenantBranding = await resolveTenantBranding(host);
-
-  try {
-    const supabase = getSupabaseClient();
-    const { data, error } = await supabase.rpc("rpc_delete_tenant_domain", {
-      p_domain_id: domainId
-    });
-
-    if (error) {
-      return NextResponse.json(
-        { ok: false, error: error.message },
-        { status: error.code === "42501" ? 403 : 400 }
-      );
-    }
-
-    return NextResponse.json({ ok: true, removed: data }, { status: 200 });
-  } catch (error) {
-    if (error instanceof SupabaseConfigurationError) {
-      return NextResponse.json({ ok: false, error: error.message }, { status: 503 });
-    }
-    return NextResponse.json({ ok: false, error: (error as Error).message }, { status: 500 });
-  }
-}
+export const POST = routes.POST;
+export const PATCH = routes.PATCH;
+export const DELETE = routes.DELETE;
 
 export const dynamic = "force-dynamic";
+
+export type { DomainRouteDependencies };

--- a/packages/db/migrations/202502150001_audit_tenant_branding_domains.sql
+++ b/packages/db/migrations/202502150001_audit_tenant_branding_domains.sql
@@ -1,0 +1,333 @@
+create or replace function public.rpc_upsert_tenant_branding(
+  p_tenant_org_id uuid,
+  p_tokens jsonb,
+  p_logo_url text,
+  p_favicon_url text,
+  p_typography jsonb,
+  p_pdf_header jsonb,
+  p_pdf_footer jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  normalized_tokens jsonb := coalesce(p_tokens, '{}'::jsonb);
+  normalized_typography jsonb := coalesce(p_typography, '{}'::jsonb);
+  normalized_pdf_header jsonb := coalesce(p_pdf_header, '{}'::jsonb);
+  normalized_pdf_footer jsonb := coalesce(p_pdf_footer, '{}'::jsonb);
+  previous tenant_branding;
+  result tenant_branding;
+  audit_payload jsonb;
+  audit_entry jsonb;
+  actor_id uuid := auth.uid();
+begin
+  perform public.assert_tenant_membership(p_tenant_org_id);
+
+  select * into previous
+  from tenant_branding
+  where tenant_org_id = p_tenant_org_id;
+
+  insert into tenant_branding as tb (
+    tenant_org_id,
+    tokens,
+    logo_url,
+    favicon_url,
+    typography,
+    pdf_header,
+    pdf_footer,
+    updated_at
+  )
+  values (
+    p_tenant_org_id,
+    normalized_tokens,
+    p_logo_url,
+    p_favicon_url,
+    normalized_typography,
+    normalized_pdf_header,
+    normalized_pdf_footer,
+    now()
+  )
+  on conflict (tenant_org_id) do update
+    set tokens = excluded.tokens,
+        logo_url = excluded.logo_url,
+        favicon_url = excluded.favicon_url,
+        typography = excluded.typography,
+        pdf_header = excluded.pdf_header,
+        pdf_footer = excluded.pdf_footer,
+        updated_at = now()
+  returning * into result;
+
+  audit_payload := jsonb_build_object(
+    'tenant_org_id', p_tenant_org_id,
+    'previous', to_jsonb(previous),
+    'current', to_jsonb(result)
+  );
+
+  audit_entry := public.rpc_append_audit_entry(
+    action => 'tenant_branding_update',
+    actor_id => actor_id,
+    reason_code => 'tenant_branding_update',
+    payload => audit_payload,
+    target_kind => 'tenant_branding',
+    target_id => p_tenant_org_id,
+    tenant_org_id => p_tenant_org_id,
+    actor_org_id => p_tenant_org_id
+  );
+
+  if audit_entry is not null then
+    audit_entry := audit_entry || jsonb_build_object(
+      'reason_code', 'tenant_branding_update',
+      'payload', audit_payload
+    );
+  end if;
+
+  return jsonb_build_object(
+    'branding', to_jsonb(result),
+    'audit_entry', audit_entry
+  );
+end;
+$$;
+
+grant execute on function public.rpc_upsert_tenant_branding(uuid, jsonb, text, text, jsonb, jsonb, jsonb) to authenticated, service_role;
+
+create or replace function public.rpc_upsert_tenant_domain(
+  p_tenant_org_id uuid,
+  p_domain text,
+  p_is_primary boolean default false
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  normalized_domain text;
+  previous tenant_domains;
+  result tenant_domains;
+  audit_payload jsonb;
+  audit_entry jsonb;
+  demoted_domains jsonb := '[]'::jsonb;
+  actor_id uuid := auth.uid();
+begin
+  perform public.assert_tenant_membership(p_tenant_org_id);
+
+  normalized_domain := public.normalize_domain(p_domain);
+
+  if normalized_domain is null or length(trim(normalized_domain)) = 0 then
+    raise exception 'Domain value required' using errcode = '22023';
+  end if;
+
+  select * into previous
+  from tenant_domains
+  where domain = normalized_domain;
+
+  insert into tenant_domains as td (
+    tenant_org_id,
+    domain,
+    is_primary,
+    cert_status,
+    updated_at
+  )
+  values (
+    p_tenant_org_id,
+    normalized_domain,
+    coalesce(p_is_primary, false),
+    'pending',
+    now()
+  )
+  on conflict (domain) do update
+    set tenant_org_id = excluded.tenant_org_id,
+        is_primary = excluded.is_primary,
+        updated_at = now()
+  returning * into result;
+
+  if result.is_primary then
+    demoted_domains := coalesce(
+      (
+        select jsonb_agg(jsonb_build_object('id', id, 'domain', domain))
+        from tenant_domains
+        where tenant_org_id = p_tenant_org_id
+          and id <> result.id
+          and is_primary
+      ),
+      '[]'::jsonb
+    );
+
+    update tenant_domains
+    set is_primary = false,
+        updated_at = now()
+    where tenant_org_id = p_tenant_org_id
+      and id <> result.id
+      and is_primary;
+  end if;
+
+  audit_payload := jsonb_build_object(
+    'domain', result.domain,
+    'previous', to_jsonb(previous),
+    'current', to_jsonb(result),
+    'demoted_domains', demoted_domains
+  );
+
+  audit_entry := public.rpc_append_audit_entry(
+    action => 'tenant_domain_claim',
+    actor_id => actor_id,
+    reason_code => 'tenant_domain_claim',
+    payload => audit_payload,
+    target_kind => 'tenant_domain',
+    target_id => result.id,
+    tenant_org_id => result.tenant_org_id,
+    actor_org_id => result.tenant_org_id
+  );
+
+  if audit_entry is not null then
+    audit_entry := audit_entry || jsonb_build_object(
+      'reason_code', 'tenant_domain_claim',
+      'payload', audit_payload
+    );
+  end if;
+
+  return jsonb_build_object(
+    'domain', to_jsonb(result),
+    'audit_entry', audit_entry
+  );
+end;
+$$;
+
+grant execute on function public.rpc_upsert_tenant_domain(uuid, text, boolean) to authenticated, service_role;
+
+create or replace function public.rpc_mark_tenant_domain_verified(
+  p_domain_id uuid,
+  p_cert_status text,
+  p_verified_at timestamptz default now()
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  result tenant_domains;
+  previous tenant_domains;
+  audit_payload jsonb;
+  audit_entry jsonb;
+  tenant_id uuid;
+  actor_id uuid := auth.uid();
+begin
+  select * into previous
+  from tenant_domains
+  where id = p_domain_id;
+
+  if previous.id is null then
+    raise exception 'Domain not found' using errcode = 'P0002';
+  end if;
+
+  tenant_id := previous.tenant_org_id;
+
+  perform public.assert_tenant_membership(tenant_id);
+
+  update tenant_domains
+  set verified_at = p_verified_at,
+      cert_status = coalesce(p_cert_status, cert_status),
+      updated_at = now()
+  where id = p_domain_id
+  returning * into result;
+
+  audit_payload := jsonb_build_object(
+    'domain', result.domain,
+    'previous', to_jsonb(previous),
+    'current', to_jsonb(result)
+  );
+
+  audit_entry := public.rpc_append_audit_entry(
+    action => 'tenant_domain_verify',
+    actor_id => actor_id,
+    reason_code => 'tenant_domain_verify',
+    payload => audit_payload,
+    target_kind => 'tenant_domain',
+    target_id => result.id,
+    tenant_org_id => result.tenant_org_id,
+    actor_org_id => result.tenant_org_id
+  );
+
+  if audit_entry is not null then
+    audit_entry := audit_entry || jsonb_build_object(
+      'reason_code', 'tenant_domain_verify',
+      'payload', audit_payload
+    );
+  end if;
+
+  return jsonb_build_object(
+    'domain', to_jsonb(result),
+    'audit_entry', audit_entry
+  );
+end;
+$$;
+
+grant execute on function public.rpc_mark_tenant_domain_verified(uuid, text, timestamptz) to authenticated, service_role;
+
+create or replace function public.rpc_delete_tenant_domain(
+  p_domain_id uuid
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  existing tenant_domains;
+  removed boolean := false;
+  removed_count integer := 0;
+  audit_payload jsonb;
+  audit_entry jsonb;
+  actor_id uuid := auth.uid();
+begin
+  select * into existing
+  from tenant_domains
+  where id = p_domain_id;
+
+  if existing.id is null then
+    raise exception 'Domain not found' using errcode = 'P0002';
+  end if;
+
+  perform public.assert_tenant_membership(existing.tenant_org_id);
+
+  delete from tenant_domains
+  where id = p_domain_id;
+  get diagnostics removed_count = row_count;
+  removed := removed_count > 0;
+
+  if removed then
+    audit_payload := jsonb_build_object(
+      'domain', existing.domain,
+      'deleted', to_jsonb(existing)
+    );
+
+    audit_entry := public.rpc_append_audit_entry(
+      action => 'tenant_domain_delete',
+      actor_id => actor_id,
+      reason_code => 'tenant_domain_delete',
+      payload => audit_payload,
+      target_kind => 'tenant_domain',
+      target_id => existing.id,
+      tenant_org_id => existing.tenant_org_id,
+      actor_org_id => existing.tenant_org_id
+    );
+
+    if audit_entry is not null then
+      audit_entry := audit_entry || jsonb_build_object(
+        'reason_code', 'tenant_domain_delete',
+        'payload', audit_payload
+      );
+    end if;
+  end if;
+
+  return jsonb_build_object(
+    'removed', removed,
+    'audit_entry', audit_entry
+  );
+end;
+$$;
+
+grant execute on function public.rpc_delete_tenant_domain(uuid) to authenticated, service_role;

--- a/packages/types/src/supabase.ts
+++ b/packages/types/src/supabase.ts
@@ -1827,7 +1827,7 @@ export type Database = {
         Args: {
           p_domain_id: string;
         };
-        Returns: boolean;
+        Returns: Json;
       };
       rpc_get_tenant_branding: {
         Args: {
@@ -1892,7 +1892,7 @@ export type Database = {
           p_cert_status: string;
           p_verified_at?: string;
         };
-        Returns: Database["public"]["Tables"]["tenant_domains"]["Row"] | null;
+        Returns: Json;
       };
       rpc_upsert_tenant_branding: {
         Args: {
@@ -1904,7 +1904,7 @@ export type Database = {
           p_pdf_header: Json;
           p_pdf_footer: Json;
         };
-        Returns: Database["public"]["Tables"]["tenant_branding"]["Row"];
+        Returns: Json;
       };
       rpc_upsert_tenant_domain: {
         Args: {
@@ -1912,7 +1912,7 @@ export type Database = {
           p_domain: string;
           p_is_primary?: boolean;
         };
-        Returns: Database["public"]["Tables"]["tenant_domains"]["Row"];
+        Returns: Json;
       };
     };
     Enums: {


### PR DESCRIPTION
## Summary
- wrap tenant branding and domain RPCs with audit logging helpers and metadata payloads
- update Supabase types and partner-admin API routes to surface audit context and failures
- add partner-admin route tests covering audit propagation for branding and domain workflows

## Testing
- pnpm --filter @airnub/portal test

------
https://chatgpt.com/codex/tasks/task_e_68e023e8ffe883249c92f6bd4773cbc1