### PR TITLE
Add Freshness tables with RLS and audit hooks

### DIFF
--- a/packages/db/check-rls.mjs
+++ b/packages/db/check-rls.mjs
@@ -18,7 +18,17 @@ const tablesWithRls = [
   "audit_log",
   "admin_actions",
   "dsr_requests",
-  "dsr_request_jobs"
+  "dsr_request_jobs",
+  "source_registry",
+  "source_snapshot",
+  "change_event",
+  "rule_versions",
+  "template_versions",
+  "workflow_def_versions",
+  "workflow_pack_versions",
+  "moderation_queue",
+  "release_notes",
+  "adoption_records"
 ];
 
 const missingRls = tablesWithRls.filter((table) => {
@@ -50,7 +60,48 @@ const requiredPolicies = {
   audit_log: ["Members read audit log", "Service role appends audit log"],
   admin_actions: ["Members read admin actions", "Service role appends admin actions"],
   dsr_requests: ["Members view DSR requests", "Members manage DSR requests"],
-  dsr_request_jobs: ["Service role manages DSR jobs"]
+  dsr_request_jobs: ["Service role manages DSR jobs"],
+  source_registry: [
+    "Service role manages source registry",
+    "Tenant members read source registry"
+  ],
+  source_snapshot: [
+    "Service role manages source snapshots",
+    "Tenant members read source snapshots"
+  ],
+  change_event: [
+    "Service role manages change events",
+    "Tenant members read change events"
+  ],
+  rule_versions: [
+    "Service role manages rule versions",
+    "Tenant members read rule versions"
+  ],
+  template_versions: [
+    "Service role manages template versions",
+    "Tenant members read template versions"
+  ],
+  workflow_def_versions: [
+    "Service role manages workflow def versions",
+    "Tenant members read workflow def versions"
+  ],
+  workflow_pack_versions: [
+    "Service role manages workflow pack versions",
+    "Tenant members read workflow pack versions"
+  ],
+  moderation_queue: [
+    "Service role manages moderation queue",
+    "Tenant members view moderation queue"
+  ],
+  release_notes: [
+    "Service role manages release notes",
+    "Tenant members read release notes"
+  ],
+  adoption_records: [
+    "Service role manages adoption records",
+    "Tenant members read adoption records",
+    "Tenant members insert adoption records"
+  ]
 };
 
 const missingPolicies = Object.entries(requiredPolicies).flatMap(([table, policies]) =>

--- a/packages/db/migrations/202503150001_freshness_tables.sql
+++ b/packages/db/migrations/202503150001_freshness_tables.sql
@@ -1,0 +1,387 @@
+begin;
+
+create table if not exists source_registry (
+  id uuid primary key default gen_random_uuid(),
+  tenant_org_id uuid not null references organisations(id),
+  name text not null,
+  url text not null,
+  parser text not null,
+  jurisdiction text,
+  category text,
+  created_at timestamptz not null default now(),
+  unique (tenant_org_id, url)
+);
+
+create index if not exists source_registry_tenant_idx on source_registry(tenant_org_id);
+
+create table if not exists source_snapshot (
+  id uuid primary key default gen_random_uuid(),
+  tenant_org_id uuid not null references organisations(id),
+  source_id uuid not null references source_registry(id) on delete cascade,
+  fetched_at timestamptz not null default now(),
+  content_hash text not null,
+  parsed_facts jsonb not null,
+  storage_ref text,
+  created_at timestamptz not null default now(),
+  unique (source_id, content_hash)
+);
+
+create index if not exists source_snapshot_source_idx on source_snapshot(source_id, fetched_at desc);
+create index if not exists source_snapshot_tenant_idx on source_snapshot(tenant_org_id);
+
+create table if not exists change_event (
+  id uuid primary key default gen_random_uuid(),
+  tenant_org_id uuid not null references organisations(id),
+  source_id uuid not null references source_registry(id) on delete cascade,
+  from_hash text,
+  to_hash text not null,
+  detected_at timestamptz not null default now(),
+  severity text not null,
+  notes text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists change_event_source_idx on change_event(source_id, detected_at desc);
+create index if not exists change_event_tenant_idx on change_event(tenant_org_id, detected_at desc);
+
+create table if not exists rule_versions (
+  id uuid primary key default gen_random_uuid(),
+  tenant_org_id uuid not null references organisations(id),
+  rule_id text not null,
+  version text not null,
+  logic_jsonb jsonb not null,
+  sources jsonb not null,
+  checksum text not null,
+  created_by uuid references users(id),
+  created_at timestamptz not null default now(),
+  unique (tenant_org_id, rule_id, version)
+);
+
+create index if not exists rule_versions_rule_idx on rule_versions(rule_id);
+create index if not exists rule_versions_tenant_idx on rule_versions(tenant_org_id);
+
+create table if not exists template_versions (
+  id uuid primary key default gen_random_uuid(),
+  tenant_org_id uuid not null references organisations(id),
+  template_id text not null,
+  version text not null,
+  storage_ref text not null,
+  checksum text not null,
+  created_by uuid references users(id),
+  created_at timestamptz not null default now(),
+  unique (tenant_org_id, template_id, version)
+);
+
+create index if not exists template_versions_template_idx on template_versions(template_id);
+create index if not exists template_versions_tenant_idx on template_versions(tenant_org_id);
+
+create table if not exists workflow_def_versions (
+  id uuid primary key default gen_random_uuid(),
+  tenant_org_id uuid not null references organisations(id),
+  workflow_def_id uuid not null references workflow_defs(id) on delete cascade,
+  version text not null,
+  graph_jsonb jsonb not null,
+  rule_ranges jsonb not null default '{}'::jsonb,
+  template_ranges jsonb not null default '{}'::jsonb,
+  checksum text not null,
+  created_by uuid references users(id),
+  created_at timestamptz not null default now(),
+  unique (workflow_def_id, version)
+);
+
+create index if not exists workflow_def_versions_tenant_idx on workflow_def_versions(tenant_org_id);
+
+create table if not exists workflow_pack_versions (
+  id uuid primary key default gen_random_uuid(),
+  tenant_org_id uuid not null references organisations(id),
+  pack_id text not null,
+  version text not null,
+  overlay_jsonb jsonb not null,
+  checksum text not null,
+  created_by uuid references users(id),
+  created_at timestamptz not null default now(),
+  unique (tenant_org_id, pack_id, version)
+);
+
+create index if not exists workflow_pack_versions_pack_idx on workflow_pack_versions(pack_id);
+create index if not exists workflow_pack_versions_tenant_idx on workflow_pack_versions(tenant_org_id);
+
+create table if not exists moderation_queue (
+  id uuid primary key default gen_random_uuid(),
+  tenant_org_id uuid not null references organisations(id),
+  change_event_id uuid references change_event(id) on delete set null,
+  proposal jsonb not null,
+  status text not null default 'pending' check (status in ('pending', 'approved', 'rejected', 'amended')),
+  classification text,
+  reviewer_id uuid references users(id),
+  decided_at timestamptz,
+  created_by uuid references users(id),
+  notes_md text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists moderation_queue_tenant_status_idx on moderation_queue(tenant_org_id, status, created_at desc);
+create index if not exists moderation_queue_change_event_idx on moderation_queue(change_event_id);
+
+create table if not exists release_notes (
+  id uuid primary key default gen_random_uuid(),
+  tenant_org_id uuid not null references organisations(id),
+  scope text not null,
+  ref_id text not null,
+  from_version text,
+  to_version text not null,
+  classification text not null,
+  effective_date date,
+  notes_md text,
+  created_by uuid references users(id),
+  created_at timestamptz not null default now()
+);
+
+create index if not exists release_notes_scope_idx on release_notes(tenant_org_id, scope, ref_id);
+
+create table if not exists adoption_records (
+  id uuid primary key default gen_random_uuid(),
+  tenant_org_id uuid not null references organisations(id),
+  run_id uuid references workflow_runs(id) on delete set null,
+  scope text not null,
+  ref_id text not null,
+  from_version text,
+  to_version text not null,
+  mode text not null,
+  actor_id uuid references users(id),
+  decided_at timestamptz not null default now(),
+  notes jsonb default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists adoption_records_scope_idx on adoption_records(tenant_org_id, scope, ref_id);
+create index if not exists adoption_records_run_idx on adoption_records(run_id);
+
+alter table workflow_runs
+  add column if not exists merged_workflow_snapshot jsonb;
+
+alter table source_registry enable row level security;
+alter table source_snapshot enable row level security;
+alter table change_event enable row level security;
+alter table rule_versions enable row level security;
+alter table template_versions enable row level security;
+alter table workflow_def_versions enable row level security;
+alter table workflow_pack_versions enable row level security;
+alter table moderation_queue enable row level security;
+alter table release_notes enable row level security;
+alter table adoption_records enable row level security;
+
+create policy "Service role manages source registry" on source_registry
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Tenant members read source registry" on source_registry
+  for select
+  using (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(tenant_org_id)
+  );
+
+create policy "Service role manages source snapshots" on source_snapshot
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Tenant members read source snapshots" on source_snapshot
+  for select
+  using (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(tenant_org_id)
+  );
+
+create policy "Service role manages change events" on change_event
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Tenant members read change events" on change_event
+  for select
+  using (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(tenant_org_id)
+  );
+
+create policy "Service role manages rule versions" on rule_versions
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Tenant members read rule versions" on rule_versions
+  for select
+  using (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(tenant_org_id)
+  );
+
+create policy "Service role manages template versions" on template_versions
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Tenant members read template versions" on template_versions
+  for select
+  using (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(tenant_org_id)
+  );
+
+create policy "Service role manages workflow def versions" on workflow_def_versions
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Tenant members read workflow def versions" on workflow_def_versions
+  for select
+  using (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(tenant_org_id)
+  );
+
+create policy "Service role manages workflow pack versions" on workflow_pack_versions
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Tenant members read workflow pack versions" on workflow_pack_versions
+  for select
+  using (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(tenant_org_id)
+  );
+
+create policy "Service role manages moderation queue" on moderation_queue
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Tenant members view moderation queue" on moderation_queue
+  for select
+  using (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(tenant_org_id)
+  );
+
+create policy "Service role manages release notes" on release_notes
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Tenant members read release notes" on release_notes
+  for select
+  using (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(tenant_org_id)
+  );
+
+create policy "Service role manages adoption records" on adoption_records
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Tenant members read adoption records" on adoption_records
+  for select
+  using (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(tenant_org_id)
+  );
+
+create policy "Tenant members insert adoption records" on adoption_records
+  for insert
+  with check (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(tenant_org_id)
+  );
+
+create or replace function log_freshness_moderation_audit()
+returns trigger
+language plpgsql
+as $$
+begin
+  insert into audit_log(
+    tenant_org_id,
+    actor_user_id,
+    actor_org_id,
+    subject_org_id,
+    entity,
+    target_kind,
+    target_id,
+    action,
+    meta_json
+  )
+  values (
+    new.tenant_org_id,
+    coalesce(new.reviewer_id, new.created_by),
+    new.tenant_org_id,
+    new.tenant_org_id,
+    'moderation_queue',
+    'freshness_moderation',
+    new.id,
+    'enqueue',
+    jsonb_build_object(
+      'change_event_id', new.change_event_id,
+      'status', new.status,
+      'classification', new.classification,
+      'proposal', new.proposal
+    )
+  );
+
+  return new;
+end;
+$$;
+
+create or replace function log_freshness_adoption_audit()
+returns trigger
+language plpgsql
+as $$
+begin
+  insert into audit_log(
+    tenant_org_id,
+    actor_user_id,
+    actor_org_id,
+    subject_org_id,
+    run_id,
+    entity,
+    target_kind,
+    target_id,
+    action,
+    meta_json
+  )
+  values (
+    new.tenant_org_id,
+    new.actor_id,
+    new.tenant_org_id,
+    new.tenant_org_id,
+    new.run_id,
+    'adoption_records',
+    'freshness_adoption',
+    new.id,
+    'adopt',
+    jsonb_build_object(
+      'scope', new.scope,
+      'ref_id', new.ref_id,
+      'from_version', new.from_version,
+      'to_version', new.to_version,
+      'mode', new.mode
+    )
+  );
+
+  return new;
+end;
+$$;
+
+create trigger moderation_queue_audit_after_insert
+  after insert on moderation_queue
+  for each row execute function log_freshness_moderation_audit();
+
+create trigger adoption_records_audit_after_insert
+  after insert on adoption_records
+  for each row execute function log_freshness_adoption_audit();
+
+commit;

--- a/packages/db/schema.sql
+++ b/packages/db/schema.sql
@@ -315,6 +315,164 @@ create table funding_opportunity_workflows (
   unique(funding_opportunity_id, workflow_key)
 );
 
+create table source_registry (
+  id uuid primary key default gen_random_uuid(),
+  tenant_org_id uuid not null references organisations(id),
+  name text not null,
+  url text not null,
+  parser text not null,
+  jurisdiction text,
+  category text,
+  created_at timestamptz not null default now(),
+  unique(tenant_org_id, url)
+);
+
+create index source_registry_tenant_idx on source_registry(tenant_org_id);
+
+create table source_snapshot (
+  id uuid primary key default gen_random_uuid(),
+  tenant_org_id uuid not null references organisations(id),
+  source_id uuid not null references source_registry(id) on delete cascade,
+  fetched_at timestamptz not null default now(),
+  content_hash text not null,
+  parsed_facts jsonb not null,
+  storage_ref text,
+  created_at timestamptz not null default now(),
+  unique(source_id, content_hash)
+);
+
+create index source_snapshot_source_idx on source_snapshot(source_id, fetched_at desc);
+create index source_snapshot_tenant_idx on source_snapshot(tenant_org_id);
+
+create table change_event (
+  id uuid primary key default gen_random_uuid(),
+  tenant_org_id uuid not null references organisations(id),
+  source_id uuid not null references source_registry(id) on delete cascade,
+  from_hash text,
+  to_hash text not null,
+  detected_at timestamptz not null default now(),
+  severity text not null,
+  notes text,
+  created_at timestamptz not null default now()
+);
+
+create index change_event_source_idx on change_event(source_id, detected_at desc);
+create index change_event_tenant_idx on change_event(tenant_org_id, detected_at desc);
+
+create table rule_versions (
+  id uuid primary key default gen_random_uuid(),
+  tenant_org_id uuid not null references organisations(id),
+  rule_id text not null,
+  version text not null,
+  logic_jsonb jsonb not null,
+  sources jsonb not null,
+  checksum text not null,
+  created_by uuid references users(id),
+  created_at timestamptz not null default now(),
+  unique(tenant_org_id, rule_id, version)
+);
+
+create index rule_versions_rule_idx on rule_versions(rule_id);
+create index rule_versions_tenant_idx on rule_versions(tenant_org_id);
+
+create table template_versions (
+  id uuid primary key default gen_random_uuid(),
+  tenant_org_id uuid not null references organisations(id),
+  template_id text not null,
+  version text not null,
+  storage_ref text not null,
+  checksum text not null,
+  created_by uuid references users(id),
+  created_at timestamptz not null default now(),
+  unique(tenant_org_id, template_id, version)
+);
+
+create index template_versions_template_idx on template_versions(template_id);
+create index template_versions_tenant_idx on template_versions(tenant_org_id);
+
+create table workflow_def_versions (
+  id uuid primary key default gen_random_uuid(),
+  tenant_org_id uuid not null references organisations(id),
+  workflow_def_id uuid not null references workflow_defs(id) on delete cascade,
+  version text not null,
+  graph_jsonb jsonb not null,
+  rule_ranges jsonb not null default '{}'::jsonb,
+  template_ranges jsonb not null default '{}'::jsonb,
+  checksum text not null,
+  created_by uuid references users(id),
+  created_at timestamptz not null default now(),
+  unique(workflow_def_id, version)
+);
+
+create index workflow_def_versions_tenant_idx on workflow_def_versions(tenant_org_id);
+
+create table workflow_pack_versions (
+  id uuid primary key default gen_random_uuid(),
+  tenant_org_id uuid not null references organisations(id),
+  pack_id text not null,
+  version text not null,
+  overlay_jsonb jsonb not null,
+  checksum text not null,
+  created_by uuid references users(id),
+  created_at timestamptz not null default now(),
+  unique(tenant_org_id, pack_id, version)
+);
+
+create index workflow_pack_versions_pack_idx on workflow_pack_versions(pack_id);
+create index workflow_pack_versions_tenant_idx on workflow_pack_versions(tenant_org_id);
+
+create table moderation_queue (
+  id uuid primary key default gen_random_uuid(),
+  tenant_org_id uuid not null references organisations(id),
+  change_event_id uuid references change_event(id) on delete set null,
+  proposal jsonb not null,
+  status text not null default 'pending' check (status in ('pending', 'approved', 'rejected', 'amended')),
+  classification text,
+  reviewer_id uuid references users(id),
+  decided_at timestamptz,
+  created_by uuid references users(id),
+  notes_md text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index moderation_queue_tenant_status_idx on moderation_queue(tenant_org_id, status, created_at desc);
+create index moderation_queue_change_event_idx on moderation_queue(change_event_id);
+
+create table release_notes (
+  id uuid primary key default gen_random_uuid(),
+  tenant_org_id uuid not null references organisations(id),
+  scope text not null,
+  ref_id text not null,
+  from_version text,
+  to_version text not null,
+  classification text not null,
+  effective_date date,
+  notes_md text,
+  created_by uuid references users(id),
+  created_at timestamptz not null default now()
+);
+
+create index release_notes_scope_idx on release_notes(tenant_org_id, scope, ref_id);
+
+create table adoption_records (
+  id uuid primary key default gen_random_uuid(),
+  tenant_org_id uuid not null references organisations(id),
+  run_id uuid references workflow_runs(id) on delete set null,
+  scope text not null,
+  ref_id text not null,
+  from_version text,
+  to_version text not null,
+  mode text not null,
+  actor_id uuid references users(id),
+  decided_at timestamptz not null default now(),
+  notes jsonb default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index adoption_records_scope_idx on adoption_records(tenant_org_id, scope, ref_id);
+create index adoption_records_run_idx on adoption_records(run_id);
+
 create or replace function public.current_tenant_org_id()
 returns uuid
 language sql
@@ -414,6 +572,16 @@ alter table workflow_overlay_snapshots enable row level security;
 alter table workflow_overlay_layers enable row level security;
 alter table dsr_requests enable row level security;
 alter table dsr_request_jobs enable row level security;
+alter table source_registry enable row level security;
+alter table source_snapshot enable row level security;
+alter table change_event enable row level security;
+alter table rule_versions enable row level security;
+alter table template_versions enable row level security;
+alter table workflow_def_versions enable row level security;
+alter table workflow_pack_versions enable row level security;
+alter table moderation_queue enable row level security;
+alter table release_notes enable row level security;
+alter table adoption_records enable row level security;
 
 create policy "Members read organisations" on organisations
   for select
@@ -604,6 +772,133 @@ create policy "Service role manages DSR jobs" on dsr_request_jobs
   for all
   using (public.is_platform_service())
   with check (public.is_platform_service());
+
+create policy "Service role manages source registry" on source_registry
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Tenant members read source registry" on source_registry
+  for select
+  using (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(tenant_org_id)
+  );
+
+create policy "Service role manages source snapshots" on source_snapshot
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Tenant members read source snapshots" on source_snapshot
+  for select
+  using (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(tenant_org_id)
+  );
+
+create policy "Service role manages change events" on change_event
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Tenant members read change events" on change_event
+  for select
+  using (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(tenant_org_id)
+  );
+
+create policy "Service role manages rule versions" on rule_versions
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Tenant members read rule versions" on rule_versions
+  for select
+  using (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(tenant_org_id)
+  );
+
+create policy "Service role manages template versions" on template_versions
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Tenant members read template versions" on template_versions
+  for select
+  using (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(tenant_org_id)
+  );
+
+create policy "Service role manages workflow def versions" on workflow_def_versions
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Tenant members read workflow def versions" on workflow_def_versions
+  for select
+  using (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(tenant_org_id)
+  );
+
+create policy "Service role manages workflow pack versions" on workflow_pack_versions
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Tenant members read workflow pack versions" on workflow_pack_versions
+  for select
+  using (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(tenant_org_id)
+  );
+
+create policy "Service role manages moderation queue" on moderation_queue
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Tenant members view moderation queue" on moderation_queue
+  for select
+  using (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(tenant_org_id)
+  );
+
+create policy "Service role manages release notes" on release_notes
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Tenant members read release notes" on release_notes
+  for select
+  using (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(tenant_org_id)
+  );
+
+create policy "Service role manages adoption records" on adoption_records
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Tenant members read adoption records" on adoption_records
+  for select
+  using (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(tenant_org_id)
+  );
+
+create policy "Tenant members insert adoption records" on adoption_records
+  for insert
+  with check (
+    auth.role() = 'service_role'
+    or public.is_member_of_org(tenant_org_id)
+  );
 
 create policy "Service role manages json schemas" on json_schemas
   for all
@@ -869,6 +1164,91 @@ create constraint trigger audit_log_block_mutations
 create constraint trigger admin_actions_block_mutations
   after update or delete on admin_actions
   for each statement execute function raise_append_only();
+
+create or replace function log_freshness_moderation_audit()
+returns trigger
+language plpgsql
+as $$
+begin
+  insert into audit_log(
+    tenant_org_id,
+    actor_user_id,
+    actor_org_id,
+    subject_org_id,
+    entity,
+    target_kind,
+    target_id,
+    action,
+    meta_json
+  )
+  values (
+    new.tenant_org_id,
+    coalesce(new.reviewer_id, new.created_by),
+    new.tenant_org_id,
+    new.tenant_org_id,
+    'moderation_queue',
+    'freshness_moderation',
+    new.id,
+    'enqueue',
+    jsonb_build_object(
+      'change_event_id', new.change_event_id,
+      'status', new.status,
+      'classification', new.classification,
+      'proposal', new.proposal
+    )
+  );
+
+  return new;
+end;
+$$;
+
+create or replace function log_freshness_adoption_audit()
+returns trigger
+language plpgsql
+as $$
+begin
+  insert into audit_log(
+    tenant_org_id,
+    actor_user_id,
+    actor_org_id,
+    subject_org_id,
+    run_id,
+    entity,
+    target_kind,
+    target_id,
+    action,
+    meta_json
+  )
+  values (
+    new.tenant_org_id,
+    new.actor_id,
+    new.tenant_org_id,
+    new.tenant_org_id,
+    new.run_id,
+    'adoption_records',
+    'freshness_adoption',
+    new.id,
+    'adopt',
+    jsonb_build_object(
+      'scope', new.scope,
+      'ref_id', new.ref_id,
+      'from_version', new.from_version,
+      'to_version', new.to_version,
+      'mode', new.mode
+    )
+  );
+
+  return new;
+end;
+$$;
+
+create trigger moderation_queue_audit_after_insert
+  after insert on moderation_queue
+  for each row execute function log_freshness_moderation_audit();
+
+create trigger adoption_records_audit_after_insert
+  after insert on adoption_records
+  for each row execute function log_freshness_adoption_audit();
 
 create or replace function rpc_append_audit_entry(
   action text,

--- a/packages/db/tests/freshness_tables_rls.test.sql
+++ b/packages/db/tests/freshness_tables_rls.test.sql
@@ -1,0 +1,120 @@
+-- Freshness tables enforce tenant isolation and audit logging
+begin;
+
+do $$
+declare
+  tenant_one constant uuid := '00000000-0000-0000-0000-000000000101';
+  tenant_two constant uuid := '00000000-0000-0000-0000-000000000202';
+  user_one constant uuid := '00000000-0000-0000-0000-000000000901';
+  user_two constant uuid := '00000000-0000-0000-0000-000000000902';
+  v_source_id uuid;
+  v_change_event_id uuid;
+  v_moderation_id uuid;
+  v_adoption_id uuid;
+  v_count integer;
+  audit_rows integer;
+begin
+  perform set_config('request.jwt.claim.role', 'service_role', true);
+
+  insert into organisations (id, tenant_org_id, name, slug)
+  values
+    (tenant_one, tenant_one, 'Tenant One', 'tenant-one'),
+    (tenant_two, tenant_two, 'Tenant Two', 'tenant-two')
+  on conflict (id) do nothing;
+
+  insert into users (id, email)
+  values
+    (user_one, 'user1@example.com'),
+    (user_two, 'user2@example.com')
+  on conflict (id) do nothing;
+
+  insert into memberships (user_id, org_id, role)
+  values
+    (user_one, tenant_one, 'admin'),
+    (user_two, tenant_two, 'admin')
+  on conflict do nothing;
+
+  insert into source_registry (tenant_org_id, name, url, parser, jurisdiction, category)
+  values (tenant_one, 'CRO Guidance', 'https://example.test/cro', 'html', 'ie', 'cro')
+  returning id into v_source_id;
+
+  insert into source_snapshot (tenant_org_id, source_id, content_hash, parsed_facts, storage_ref)
+  values (tenant_one, v_source_id, 'hash-1', '{"facts":[]}'::jsonb, 's3://bucket/object');
+
+  insert into change_event (tenant_org_id, source_id, from_hash, to_hash, severity, notes)
+  values (tenant_one, v_source_id, 'hash-0', 'hash-1', 'minor', 'Detected diff')
+  returning id into v_change_event_id;
+
+  select count(*) into audit_rows from audit_log;
+
+  insert into moderation_queue (tenant_org_id, change_event_id, proposal, status, classification, created_by)
+  values (
+    tenant_one,
+    v_change_event_id,
+    jsonb_build_object('rule', 'rbo_deadline', 'bump', 'minor'),
+    'pending',
+    null,
+    user_one
+  )
+  returning id into v_moderation_id;
+
+  select count(*)
+  into v_count
+  from audit_log
+  where entity = 'moderation_queue'
+    and target_id = v_moderation_id;
+
+  if v_count <> 1 then
+    raise exception 'Moderation queue insert did not append audit log entry';
+  end if;
+
+  perform set_config('request.jwt.claim.role', 'authenticated', true);
+  perform set_config('request.jwt.claim.sub', user_one::text, true);
+  perform set_config('request.jwt.claim.tenant_org_id', tenant_one::text, true);
+
+  select count(*) into v_count from source_registry;
+  if v_count <> 1 then
+    raise exception 'Tenant member should read own source registry entries';
+  end if;
+
+  select count(*) into v_count from moderation_queue;
+  if v_count <> 1 then
+    raise exception 'Tenant member should read moderation queue entries';
+  end if;
+
+  select count(*) into audit_rows from audit_log;
+
+  insert into adoption_records (tenant_org_id, scope, ref_id, from_version, to_version, mode, actor_id)
+  values (tenant_one, 'rule', 'rbo_deadline', '1.0.0', '1.1.0', 'manual', user_one)
+  returning id into v_adoption_id;
+
+  select count(*)
+  into v_count
+  from audit_log
+  where entity = 'adoption_records'
+    and target_id = v_adoption_id;
+
+  if v_count <> 1 then
+    raise exception 'Adoption record insert did not append audit log entry';
+  end if;
+
+  perform set_config('request.jwt.claim.sub', user_two::text, true);
+  perform set_config('request.jwt.claim.tenant_org_id', tenant_two::text, true);
+
+  select count(*) into v_count from source_registry;
+  if v_count <> 0 then
+    raise exception 'Cross-tenant read should be blocked by RLS';
+  end if;
+
+  begin
+    insert into adoption_records (tenant_org_id, scope, ref_id, to_version, mode, actor_id)
+    values (tenant_one, 'workflow', 'setup', '2.0.0', 'manual', user_two);
+    raise exception 'Cross-tenant insert should have been blocked';
+  exception
+    when sqlstate '42501' then
+      null;
+  end;
+end;
+$$;
+
+rollback;

--- a/packages/types/src/supabase.ts
+++ b/packages/types/src/supabase.ts
@@ -9,132 +9,551 @@ export type Json =
 export type Database = {
   public: {
     Tables: {
-      freshness_snapshots: {
+      adoption_records: {
         Row: {
           id: string;
-          source_key: string;
-          fingerprint: string;
-          payload: Json;
-          polled_at: string;
-          metadata: Json | null;
+          tenant_org_id: string;
+          run_id: string | null;
+          scope: string;
+          ref_id: string;
+          from_version: string | null;
+          to_version: string;
+          mode: string;
+          actor_id: string | null;
+          decided_at: string;
+          notes: Json | null;
+          created_at: string;
         };
         Insert: {
           id?: string;
-          source_key: string;
-          fingerprint: string;
-          payload: Json;
-          polled_at?: string;
-          metadata?: Json | null;
+          tenant_org_id: string;
+          run_id?: string | null;
+          scope: string;
+          ref_id: string;
+          from_version?: string | null;
+          to_version: string;
+          mode: string;
+          actor_id?: string | null;
+          decided_at?: string;
+          notes?: Json | null;
+          created_at?: string;
         };
         Update: {
           id?: string;
-          source_key?: string;
-          fingerprint?: string;
-          payload?: Json;
-          polled_at?: string;
-          metadata?: Json | null;
-        };
-        Relationships: [];
-      };
-      freshness_pending_updates: {
-        Row: {
-          id: string;
-          source_key: string;
-          current_snapshot_id: string;
-          previous_snapshot_id: string | null;
-          status: "pending" | "approved" | "rejected";
-          diff_summary: string;
-          diff_payload: Json | null;
-          detected_at: string;
-          approval_reason: string | null;
-          rejection_reason: string | null;
-          approved_by_user_id: string | null;
-          workflow_keys: string[] | null;
-          verified_at: string | null;
-          created_at: string | null;
-          updated_at: string | null;
-        };
-        Insert: {
-          id?: string;
-          source_key: string;
-          current_snapshot_id: string;
-          previous_snapshot_id?: string | null;
-          status?: "pending" | "approved" | "rejected";
-          diff_summary: string;
-          diff_payload?: Json | null;
-          detected_at?: string;
-          approval_reason?: string | null;
-          rejection_reason?: string | null;
-          approved_by_user_id?: string | null;
-          workflow_keys?: string[] | null;
-          verified_at?: string | null;
-          created_at?: string | null;
-          updated_at?: string | null;
-        };
-        Update: {
-          id?: string;
-          source_key?: string;
-          current_snapshot_id?: string;
-          previous_snapshot_id?: string | null;
-          status?: "pending" | "approved" | "rejected";
-          diff_summary?: string;
-          diff_payload?: Json | null;
-          detected_at?: string;
-          approval_reason?: string | null;
-          rejection_reason?: string | null;
-          approved_by_user_id?: string | null;
-          workflow_keys?: string[] | null;
-          verified_at?: string | null;
-          created_at?: string | null;
-          updated_at?: string | null;
+          tenant_org_id?: string;
+          run_id?: string | null;
+          scope?: string;
+          ref_id?: string;
+          from_version?: string | null;
+          to_version?: string;
+          mode?: string;
+          actor_id?: string | null;
+          decided_at?: string;
+          notes?: Json | null;
+          created_at?: string;
         };
         Relationships: [
           {
-            foreignKeyName: "freshness_pending_updates_approved_by_user_id_fkey";
-            columns: ["approved_by_user_id"];
+            foreignKeyName: "adoption_records_actor_id_fkey";
+            columns: ["actor_id"];
             isOneToOne: false;
             referencedRelation: "users";
             referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "freshness_pending_updates_current_snapshot_id_fkey";
-            columns: ["current_snapshot_id"];
+            foreignKeyName: "adoption_records_run_id_fkey";
+            columns: ["run_id"];
             isOneToOne: false;
-            referencedRelation: "freshness_snapshots";
+            referencedRelation: "workflow_runs";
             referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "freshness_pending_updates_previous_snapshot_id_fkey";
-            columns: ["previous_snapshot_id"];
+            foreignKeyName: "adoption_records_tenant_org_id_fkey";
+            columns: ["tenant_org_id"];
             isOneToOne: false;
-            referencedRelation: "freshness_snapshots";
+            referencedRelation: "organisations";
             referencedColumns: ["id"];
           }
         ];
       };
-      freshness_rule_verifications: {
+      change_event: {
         Row: {
           id: string;
-          rule_id: string;
-          evidence: Json;
-          verified_at: string;
-          created_at: string | null;
+          tenant_org_id: string;
+          source_id: string;
+          from_hash: string | null;
+          to_hash: string;
+          detected_at: string;
+          severity: string;
+          notes: string | null;
+          created_at: string;
         };
         Insert: {
           id?: string;
-          rule_id: string;
-          evidence: Json;
-          verified_at: string;
-          created_at?: string | null;
+          tenant_org_id: string;
+          source_id: string;
+          from_hash?: string | null;
+          to_hash: string;
+          detected_at?: string;
+          severity: string;
+          notes?: string | null;
+          created_at?: string;
         };
         Update: {
           id?: string;
-          rule_id?: string;
-          evidence?: Json;
-          verified_at?: string;
-          created_at?: string | null;
+          tenant_org_id?: string;
+          source_id?: string;
+          from_hash?: string | null;
+          to_hash?: string;
+          detected_at?: string;
+          severity?: string;
+          notes?: string | null;
+          created_at?: string;
         };
-        Relationships: [];
+        Relationships: [
+          {
+            foreignKeyName: "change_event_source_id_fkey";
+            columns: ["source_id"];
+            isOneToOne: false;
+            referencedRelation: "source_registry";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "change_event_tenant_org_id_fkey";
+            columns: ["tenant_org_id"];
+            isOneToOne: false;
+            referencedRelation: "organisations";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+      moderation_queue: {
+        Row: {
+          id: string;
+          tenant_org_id: string;
+          change_event_id: string | null;
+          proposal: Json;
+          status: "pending" | "approved" | "rejected" | "amended";
+          classification: string | null;
+          reviewer_id: string | null;
+          decided_at: string | null;
+          created_by: string | null;
+          notes_md: string | null;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          tenant_org_id: string;
+          change_event_id?: string | null;
+          proposal: Json;
+          status?: "pending" | "approved" | "rejected" | "amended";
+          classification?: string | null;
+          reviewer_id?: string | null;
+          decided_at?: string | null;
+          created_by?: string | null;
+          notes_md?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          tenant_org_id?: string;
+          change_event_id?: string | null;
+          proposal?: Json;
+          status?: "pending" | "approved" | "rejected" | "amended";
+          classification?: string | null;
+          reviewer_id?: string | null;
+          decided_at?: string | null;
+          created_by?: string | null;
+          notes_md?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "moderation_queue_change_event_id_fkey";
+            columns: ["change_event_id"];
+            isOneToOne: false;
+            referencedRelation: "change_event";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "moderation_queue_created_by_fkey";
+            columns: ["created_by"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "moderation_queue_reviewer_id_fkey";
+            columns: ["reviewer_id"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "moderation_queue_tenant_org_id_fkey";
+            columns: ["tenant_org_id"];
+            isOneToOne: false;
+            referencedRelation: "organisations";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+      release_notes: {
+        Row: {
+          id: string;
+          tenant_org_id: string;
+          scope: string;
+          ref_id: string;
+          from_version: string | null;
+          to_version: string;
+          classification: string;
+          effective_date: string | null;
+          notes_md: string | null;
+          created_by: string | null;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          tenant_org_id: string;
+          scope: string;
+          ref_id: string;
+          from_version?: string | null;
+          to_version: string;
+          classification: string;
+          effective_date?: string | null;
+          notes_md?: string | null;
+          created_by?: string | null;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          tenant_org_id?: string;
+          scope?: string;
+          ref_id?: string;
+          from_version?: string | null;
+          to_version?: string;
+          classification?: string;
+          effective_date?: string | null;
+          notes_md?: string | null;
+          created_by?: string | null;
+          created_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "release_notes_created_by_fkey";
+            columns: ["created_by"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "release_notes_tenant_org_id_fkey";
+            columns: ["tenant_org_id"];
+            isOneToOne: false;
+            referencedRelation: "organisations";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+      rule_versions: {
+        Row: {
+          id: string;
+          tenant_org_id: string;
+          rule_id: string;
+          version: string;
+          logic_jsonb: Json;
+          sources: Json;
+          checksum: string;
+          created_by: string | null;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          tenant_org_id: string;
+          rule_id: string;
+          version: string;
+          logic_jsonb: Json;
+          sources: Json;
+          checksum: string;
+          created_by?: string | null;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          tenant_org_id?: string;
+          rule_id?: string;
+          version?: string;
+          logic_jsonb?: Json;
+          sources?: Json;
+          checksum?: string;
+          created_by?: string | null;
+          created_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "rule_versions_created_by_fkey";
+            columns: ["created_by"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "rule_versions_tenant_org_id_fkey";
+            columns: ["tenant_org_id"];
+            isOneToOne: false;
+            referencedRelation: "organisations";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+      source_registry: {
+        Row: {
+          id: string;
+          tenant_org_id: string;
+          name: string;
+          url: string;
+          parser: string;
+          jurisdiction: string | null;
+          category: string | null;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          tenant_org_id: string;
+          name: string;
+          url: string;
+          parser: string;
+          jurisdiction?: string | null;
+          category?: string | null;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          tenant_org_id?: string;
+          name?: string;
+          url?: string;
+          parser?: string;
+          jurisdiction?: string | null;
+          category?: string | null;
+          created_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "source_registry_tenant_org_id_fkey";
+            columns: ["tenant_org_id"];
+            isOneToOne: false;
+            referencedRelation: "organisations";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+      source_snapshot: {
+        Row: {
+          id: string;
+          tenant_org_id: string;
+          source_id: string;
+          fetched_at: string;
+          content_hash: string;
+          parsed_facts: Json;
+          storage_ref: string | null;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          tenant_org_id: string;
+          source_id: string;
+          fetched_at?: string;
+          content_hash: string;
+          parsed_facts: Json;
+          storage_ref?: string | null;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          tenant_org_id?: string;
+          source_id?: string;
+          fetched_at?: string;
+          content_hash?: string;
+          parsed_facts?: Json;
+          storage_ref?: string | null;
+          created_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "source_snapshot_source_id_fkey";
+            columns: ["source_id"];
+            isOneToOne: false;
+            referencedRelation: "source_registry";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "source_snapshot_tenant_org_id_fkey";
+            columns: ["tenant_org_id"];
+            isOneToOne: false;
+            referencedRelation: "organisations";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+      template_versions: {
+        Row: {
+          id: string;
+          tenant_org_id: string;
+          template_id: string;
+          version: string;
+          storage_ref: string;
+          checksum: string;
+          created_by: string | null;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          tenant_org_id: string;
+          template_id: string;
+          version: string;
+          storage_ref: string;
+          checksum: string;
+          created_by?: string | null;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          tenant_org_id?: string;
+          template_id?: string;
+          version?: string;
+          storage_ref?: string;
+          checksum?: string;
+          created_by?: string | null;
+          created_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "template_versions_created_by_fkey";
+            columns: ["created_by"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "template_versions_tenant_org_id_fkey";
+            columns: ["tenant_org_id"];
+            isOneToOne: false;
+            referencedRelation: "organisations";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+      workflow_def_versions: {
+        Row: {
+          id: string;
+          tenant_org_id: string;
+          workflow_def_id: string;
+          version: string;
+          graph_jsonb: Json;
+          rule_ranges: Json;
+          template_ranges: Json;
+          checksum: string;
+          created_by: string | null;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          tenant_org_id: string;
+          workflow_def_id: string;
+          version: string;
+          graph_jsonb: Json;
+          rule_ranges?: Json;
+          template_ranges?: Json;
+          checksum: string;
+          created_by?: string | null;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          tenant_org_id?: string;
+          workflow_def_id?: string;
+          version?: string;
+          graph_jsonb?: Json;
+          rule_ranges?: Json;
+          template_ranges?: Json;
+          checksum?: string;
+          created_by?: string | null;
+          created_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "workflow_def_versions_created_by_fkey";
+            columns: ["created_by"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "workflow_def_versions_tenant_org_id_fkey";
+            columns: ["tenant_org_id"];
+            isOneToOne: false;
+            referencedRelation: "organisations";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "workflow_def_versions_workflow_def_id_fkey";
+            columns: ["workflow_def_id"];
+            isOneToOne: false;
+            referencedRelation: "workflow_defs";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+      workflow_pack_versions: {
+        Row: {
+          id: string;
+          tenant_org_id: string;
+          pack_id: string;
+          version: string;
+          overlay_jsonb: Json;
+          checksum: string;
+          created_by: string | null;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          tenant_org_id: string;
+          pack_id: string;
+          version: string;
+          overlay_jsonb: Json;
+          checksum: string;
+          created_by?: string | null;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          tenant_org_id?: string;
+          pack_id?: string;
+          version?: string;
+          overlay_jsonb?: Json;
+          checksum?: string;
+          created_by?: string | null;
+          created_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "workflow_pack_versions_created_by_fkey";
+            columns: ["created_by"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "workflow_pack_versions_tenant_org_id_fkey";
+            columns: ["tenant_org_id"];
+            isOneToOne: false;
+            referencedRelation: "organisations";
+            referencedColumns: ["id"];
+          }
+        ];
       };
       organisations: {
         Row: {


### PR DESCRIPTION
## Summary
- add a migration defining the Freshness registry, versioning, moderation, and adoption tables with tenant RLS and audit triggers
- expand the canonical schema, Supabase types, and RLS checker to cover the new structures
- add an integration test covering tenant isolation and audit logging for the Freshness tables

## Testing
- pnpm --filter @airnub/db verify:rls

------
https://chatgpt.com/codex/tasks/task_e_68e0284c58b8832484fd6275b799dff2