### PR TITLE
Document Temporal tenant queue allow list

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,8 @@ OPENAI_API_KEY=
 TEMPORAL_ADDRESS=localhost:7233
 TEMPORAL_NAMESPACE=default
 TEMPORAL_TASK_QUEUE=fresh-comply
+# Comma-separated tenant IDs whose queues this worker may poll (e.g., tenant-acme-main,tenant-umbrella-main)
+TEMPORAL_TENANT_QUEUE_ALLOW_LIST=
 
 # Billing
 STRIPE_PUBLISHABLE_KEY=

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ pnpm run dev:worker   # launch the Temporal worker bundle
 pnpm dev              # start the Next.js portal
 ```
 
+Before starting the worker, set `TEMPORAL_TENANT_QUEUE_ALLOW_LIST` in your `.env.local` to the comma-separated tenant IDs whose queues it should process (for example, `tenant-acme-main,tenant-umbrella-main`). Workers ignore any queues not present in this allow list even if workflows reference them.
+
 The Temporal UI (http://localhost:8080) is provided for operations engineers only and should not be exposed to end users.
 
 ## Admin Runbook

--- a/docs/getting-started/codespaces.md
+++ b/docs/getting-started/codespaces.md
@@ -32,6 +32,7 @@ Our `.devcontainer` folder defines the GitHub Codespaces image for FreshComply. 
    cp apps/admin/.env.example apps/admin/.env.local 2>/dev/null || true
    ```
    Only populate the secrets you need; Supabase keys will be synced automatically.
+   If you plan to run the Temporal worker inside Codespaces, add `TEMPORAL_TENANT_QUEUE_ALLOW_LIST` to `.env.local` with the comma-separated tenant IDs whose queues you want to process (for example, `tenant-acme-main,tenant-umbrella-main`).
 3. Start the Supabase stack (the devcontainer keeps `AUTO_START_SUPABASE=false` so you control when Docker spins up):
    ```bash
    supabase start

--- a/docs/getting-started/local-development.md
+++ b/docs/getting-started/local-development.md
@@ -64,4 +64,6 @@ The portal runs on `http://localhost:3000` and the admin app on `http://localhos
 
 Copy `.env.example` to `.env.local` at the repo root and fill in any service credentials you need. The Supabase sync script updates only the keys it manages (`SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, and their `NEXT_PUBLIC_*` variants) so you can safely keep other secrets side by side.
 
+When running the Temporal worker locally, set `TEMPORAL_TENANT_QUEUE_ALLOW_LIST` to the comma-separated tenant IDs whose queues the worker should poll (for example, `tenant-acme-main,tenant-umbrella-main`). This prevents a dev worker from accidentally processing another tenant's tasks.
+
 See the [Supabase guide](../guides/supabase.md) for details on migrations, type generation, and policy patterns.


### PR DESCRIPTION
## Summary
- add the TEMPORAL_TENANT_QUEUE_ALLOW_LIST variable to the shared environment example
- document how to configure the Temporal worker allow list in the README and getting-started guides

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0301879808324b03f080c59f4c06f