### PR TITLE
Add confirmation RPC for two-step admin approvals

### DIFF
--- a/apps/admin/src/app/api/admin/__tests__/cancel-run.test.ts
+++ b/apps/admin/src/app/api/admin/__tests__/cancel-run.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { POST as cancelRun } from "../runs/[runId]/cancel/route";
+import { POST as confirmAdminAction } from "../actions/[actionId]/confirm/route";
 import { callAdminRpc, resolveAdminContext } from "../_lib";
 
 vi.mock("../_lib", async () => {
@@ -20,8 +21,8 @@ const resolveAdminContextMock = vi.mocked(resolveAdminContext);
 
 describe("cancel run handler", () => {
   beforeEach(() => {
-    callAdminRpcMock.mockClear();
-    resolveAdminContextMock.mockClear();
+    callAdminRpcMock.mockReset();
+    resolveAdminContextMock.mockReset();
     callAdminRpcMock.mockResolvedValue({ action_id: "action-123" });
     resolveAdminContextMock.mockResolvedValue({
       userId: "00000000-0000-0000-0000-000000000001",
@@ -38,7 +39,7 @@ describe("cancel run handler", () => {
       method: "POST",
       body: JSON.stringify({
         reason: "Testing",
-        approvedBy: "00000000-0000-0000-0000-000000000001",
+        secondActorId: "00000000-0000-0000-0000-000000000001",
       }),
     });
 
@@ -55,7 +56,7 @@ describe("cancel run handler", () => {
       method: "POST",
       body: JSON.stringify({
         reason: "Need to stop",
-        approvedBy: "00000000-0000-0000-0000-000000000002",
+        secondActorId: "00000000-0000-0000-0000-000000000002",
       }),
     });
 
@@ -69,6 +70,86 @@ describe("cancel run handler", () => {
       run_id: "run-9",
       reason: "Need to stop",
       second_actor_id: "00000000-0000-0000-0000-000000000002",
+      tenant_org_id: "10000000-0000-0000-0000-000000000000",
+      actor_org_id: "10000000-0000-0000-0000-000000000000",
+      on_behalf_of_org_id: null,
+    });
+  });
+});
+
+describe("confirm admin action handler", () => {
+  beforeEach(() => {
+    callAdminRpcMock.mockReset();
+    resolveAdminContextMock.mockReset();
+
+    callAdminRpcMock.mockImplementation(async (procedure, params: Record<string, unknown>) => {
+      if (procedure === "rpc_confirm_admin_action") {
+        const actorId = (params as { actor_id?: string }).actor_id;
+        if (actorId === "00000000-0000-0000-0000-000000000001") {
+          throw new Error("Second admin required");
+        }
+        return {
+          admin_action_id: (params as { action_id?: string }).action_id ?? "action-123",
+          approved_at: "2025-01-01T00:00:00.000Z",
+          audit_id: "audit-456",
+        };
+      }
+
+      return { action_id: "action-123" };
+    });
+
+    resolveAdminContextMock.mockResolvedValue({
+      userId: "00000000-0000-0000-0000-000000000001",
+      email: "actor@example.com",
+      role: "platform_admin",
+      tenantOrgId: "10000000-0000-0000-0000-000000000000",
+      actorOrgId: "10000000-0000-0000-0000-000000000000",
+      onBehalfOfOrgId: null,
+    });
+  });
+
+  it("rejects when the initiating admin tries to confirm", async () => {
+    const response = await confirmAdminAction(
+      new Request("http://localhost/api/admin/actions/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/confirm", { method: "POST" }),
+      { params: { actionId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" } },
+    );
+
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json.error).toContain("Second admin required");
+    expect(callAdminRpcMock).toHaveBeenCalledWith(
+      "rpc_confirm_admin_action",
+      expect.objectContaining({
+        action_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        actor_id: "00000000-0000-0000-0000-000000000001",
+      }),
+    );
+  });
+
+  it("approves the action when the nominated secondary admin confirms", async () => {
+    resolveAdminContextMock.mockResolvedValueOnce({
+      userId: "00000000-0000-0000-0000-000000000002",
+      email: "second@example.com",
+      role: "platform_admin",
+      tenantOrgId: "10000000-0000-0000-0000-000000000000",
+      actorOrgId: "10000000-0000-0000-0000-000000000000",
+      onBehalfOfOrgId: null,
+    });
+
+    const response = await confirmAdminAction(
+      new Request("http://localhost/api/admin/actions/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb/confirm", { method: "POST" }),
+      { params: { actionId: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb" } },
+    );
+
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.actionId).toBe("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    expect(json.approvedAt).toBe("2025-01-01T00:00:00.000Z");
+    expect(callAdminRpcMock).toHaveBeenLastCalledWith("rpc_confirm_admin_action", {
+      action_id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+      actor_id: "00000000-0000-0000-0000-000000000002",
       tenant_org_id: "10000000-0000-0000-0000-000000000000",
       actor_org_id: "10000000-0000-0000-0000-000000000000",
       on_behalf_of_org_id: null,

--- a/apps/admin/src/app/api/admin/actions/[actionId]/confirm/route.ts
+++ b/apps/admin/src/app/api/admin/actions/[actionId]/confirm/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { callAdminRpc, resolveAdminContext } from "../../../_lib";
+
+const paramsSchema = z.object({
+  actionId: z.string().uuid("Action id must be a UUID"),
+});
+
+type ConfirmResult = {
+  admin_action_id?: string;
+  approved_at?: string;
+  audit_id?: string;
+};
+
+export async function POST(_request: Request, { params }: { params: { actionId: string } }) {
+  const parsedParams = paramsSchema.safeParse(params);
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: "Invalid admin action id" }, { status: 400 });
+  }
+
+  const context = await resolveAdminContext(["platform_admin", "support_agent", "dpo"]);
+  if (context instanceof NextResponse) {
+    return context;
+  }
+
+  const tenantOrgId = context.tenantOrgId ?? context.actorOrgId;
+  const actorOrgId = context.actorOrgId ?? context.tenantOrgId;
+
+  if (!tenantOrgId || !actorOrgId) {
+    return NextResponse.json({ error: "Tenant context unavailable" }, { status: 403 });
+  }
+
+  try {
+    const result = await callAdminRpc<ConfirmResult>("rpc_confirm_admin_action", {
+      action_id: parsedParams.data.actionId,
+      actor_id: context.userId,
+      tenant_org_id: tenantOrgId,
+      actor_org_id: actorOrgId,
+      on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,
+    });
+
+    return NextResponse.json({
+      message: "Admin action approved",
+      actionId: result.admin_action_id ?? parsedParams.data.actionId,
+      approvedAt: result.approved_at ?? null,
+      auditId: result.audit_id ?? null,
+      data: result,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unable to approve admin action";
+    const details = error instanceof Error && "details" in error ? (error as { details?: string }).details : undefined;
+    return NextResponse.json({ error: message, ...(details ? { details } : {}) }, { status: 400 });
+  }
+}

--- a/apps/admin/src/app/api/admin/dsr/[requestId]/legal-hold/route.ts
+++ b/apps/admin/src/app/api/admin/dsr/[requestId]/legal-hold/route.ts
@@ -6,7 +6,7 @@ import { requiresSecondApproval } from "../../../../../../lib/rbac";
 const schema = z.object({
   reason: z.string().min(1, "Reason code is required"),
   enabled: z.boolean(),
-  approvedBy: z.string().uuid("Second approver id must be a UUID").optional(),
+  secondActorId: z.string().uuid("Second approver id must be a UUID").optional(),
 });
 
 export async function POST(request: Request, { params }: { params: { requestId: string } }) {
@@ -21,7 +21,7 @@ export async function POST(request: Request, { params }: { params: { requestId: 
   }
 
   const requiresSecond = requiresSecondApproval("legal_hold_toggle");
-  const secondActorId = parsed.approvedBy ?? null;
+  const secondActorId = parsed.secondActorId ?? null;
 
   if (requiresSecond && !secondActorId) {
     return NextResponse.json({ error: "Legal hold changes require a second approver" }, { status: 400 });

--- a/apps/admin/src/app/api/admin/runs/[runId]/cancel/route.ts
+++ b/apps/admin/src/app/api/admin/runs/[runId]/cancel/route.ts
@@ -5,7 +5,7 @@ import { requiresSecondApproval } from "../../../../../../lib/rbac";
 
 const schema = z.object({
   reason: z.string().min(1, "Reason code is required"),
-  approvedBy: z.string().uuid("Second approver id must be a UUID"),
+  secondActorId: z.string().uuid("Second approver id must be a UUID"),
 });
 
 export async function POST(request: Request, { params }: { params: { runId: string } }) {
@@ -19,7 +19,7 @@ export async function POST(request: Request, { params }: { params: { runId: stri
     return parsed;
   }
 
-  if (parsed.approvedBy === context.userId) {
+  if (parsed.secondActorId === context.userId) {
     return NextResponse.json({ error: "Second approver must be a different admin" }, { status: 400 });
   }
 
@@ -39,7 +39,7 @@ export async function POST(request: Request, { params }: { params: { runId: stri
       actor_id: context.userId,
       run_id: params.runId,
       reason: parsed.reason,
-      second_actor_id: parsed.approvedBy,
+      second_actor_id: parsed.secondActorId,
       tenant_org_id: tenantOrgId,
       actor_org_id: actorOrgId,
       on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,

--- a/apps/admin/src/app/api/admin/secrets/bindings/[bindingId]/route.ts
+++ b/apps/admin/src/app/api/admin/secrets/bindings/[bindingId]/route.ts
@@ -52,7 +52,7 @@ export async function PATCH(request: Request, { params }: { params: { bindingId:
 
 const deleteSchema = z.object({
   reason: z.string().min(1, "Reason code is required"),
-  approvedBy: z.string().uuid("Second approver id must be a UUID").optional(),
+  secondActorId: z.string().uuid("Second approver id must be a UUID").optional(),
 });
 
 export async function DELETE(request: Request, { params }: { params: { bindingId: string } }) {
@@ -66,7 +66,7 @@ export async function DELETE(request: Request, { params }: { params: { bindingId
     return parsed;
   }
 
-  const secondActorId = parsed.approvedBy ?? null;
+  const secondActorId = parsed.secondActorId ?? null;
   if (secondActorId && secondActorId === context.userId) {
     return NextResponse.json({ error: "Second approver must be another admin" }, { status: 400 });
   }

--- a/apps/admin/src/app/api/admin/temporal/runs/[runId]/cancel/route.ts
+++ b/apps/admin/src/app/api/admin/temporal/runs/[runId]/cancel/route.ts
@@ -5,7 +5,7 @@ import { requiresSecondApproval } from "../../../../../../lib/rbac";
 
 const schema = z.object({
   reason: z.string().min(1, "Reason code is required"),
-  approvedBy: z.string().uuid("Second approver id must be a UUID"),
+  secondActorId: z.string().uuid("Second approver id must be a UUID"),
 });
 
 export async function POST(request: Request, { params }: { params: { runId: string } }) {
@@ -19,7 +19,7 @@ export async function POST(request: Request, { params }: { params: { runId: stri
     return parsed;
   }
 
-  if (parsed.approvedBy === context.userId) {
+  if (parsed.secondActorId === context.userId) {
     return NextResponse.json({ error: "Second approver must be a different admin" }, { status: 400 });
   }
 
@@ -39,7 +39,7 @@ export async function POST(request: Request, { params }: { params: { runId: stri
       actor_id: context.userId,
       run_id: params.runId,
       reason: parsed.reason,
-      second_actor_id: parsed.approvedBy,
+      second_actor_id: parsed.secondActorId,
       tenant_org_id: tenantOrgId,
       actor_org_id: actorOrgId,
       on_behalf_of_org_id: context.onBehalfOfOrgId ?? null,


### PR DESCRIPTION
## Summary
- keep admin actions pending until a second approver confirms and refresh the hash chain when approvals land
- add rpc_confirm_admin_action plus an admin API endpoint for secondary confirmation
- update privileged admin routes and tests to require a separate confirmation flow

## Testing
- pnpm vitest run apps/admin/src/app/api/admin/__tests__/cancel-run.test.ts *(fails: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e030126cc883248d804194325a93a8