### PR TITLE
feat(engine): materialize lockfiles and verify sources

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -6,7 +6,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "tsx --test src/app/api/orchestration/webhook/route.test.ts src/app/api/partner-admin/branding/route.test.ts src/app/api/partner-admin/domains/route.test.ts src/components/__tests__/tenant-overlay-builder.test.ts",
+    "test": "tsx --test src/app/api/orchestration/webhook/route.test.ts src/app/api/partner-admin/branding/route.test.ts src/app/api/partner-admin/domains/route.test.ts src/components/__tests__/tenant-overlay-builder.test.ts src/server/__tests__/workflow-runs.test.ts",
     "test:a11y": "cypress run --e2e --spec cypress/e2e/accessibility.cy.ts",
     "test:pa11y": "pa11y-ci ../../pa11yci.json"
   },

--- a/apps/portal/src/server/__tests__/workflow-runs.test.ts
+++ b/apps/portal/src/server/__tests__/workflow-runs.test.ts
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import Module from "node:module";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { createInMemorySupabase } from "../../../../../packages/freshness/src/testing/inMemorySupabase.js";
+import type { OverlayReference } from "@airnub/engine/types";
+
+const TENANT_ID = "00000000-0000-0000-0000-000000000001";
+const WORKFLOW_DEF_ID = "00000000-0000-0000-0000-000000000010";
+
+const baseGraph = {
+  id: "setup-nonprofit",
+  version: "1.0.0",
+  steps: [
+    {
+      id: "base-step",
+      kind: "info",
+      title: "Base",
+      verify: [{ id: "rule.deadline" }]
+    }
+  ]
+};
+
+test("createWorkflowRun materialises lockfile and stores snapshot", async () => {
+  const overlayOperations = [
+    {
+      op: "add",
+      path: "/steps/-",
+      value: { id: "overlay-step", kind: "info", title: "Tenant step" }
+    }
+  ];
+
+  await withWorkspaceModules(async () => {
+    const { createWorkflowRun } = await import("../workflow-runs.js");
+
+    const { client, getTableRows } = createInMemorySupabase({
+      workflow_defs: [
+        {
+          id: WORKFLOW_DEF_ID,
+          key: baseGraph.id,
+          version: baseGraph.version,
+        title: "Demo",
+        dsl_json: baseGraph
+      }
+    ],
+    workflow_def_versions: [
+      {
+        id: "definition-version-1",
+        tenant_org_id: TENANT_ID,
+        workflow_def_id: WORKFLOW_DEF_ID,
+        version: baseGraph.version,
+        checksum: "wf-checksum",
+        graph_jsonb: baseGraph,
+        rule_ranges: { "rule.deadline": { version: "2.0.0" } },
+        template_ranges: { constitution: { version: "3.1.0" } }
+      }
+    ],
+    workflow_pack_versions: [
+      {
+        id: "overlay-version-1",
+        tenant_org_id: TENANT_ID,
+        pack_id: "tenant-pack",
+        version: "1.2.0",
+        checksum: "overlay-checksum",
+        overlay_jsonb: overlayOperations
+      }
+    ],
+    rule_versions: [
+      {
+        id: "rule-version-1",
+        tenant_org_id: TENANT_ID,
+        rule_id: "rule.deadline",
+        version: "2.0.0",
+        checksum: "rule-checksum",
+        sources: [
+          {
+            source_key: "cro_open_services",
+            snapshot_id: "snapshot-1",
+            fingerprint: "fingerprint-1"
+          }
+        ]
+      }
+    ],
+    template_versions: [
+      {
+        id: "template-version-1",
+        tenant_org_id: TENANT_ID,
+        template_id: "constitution",
+        version: "3.1.0",
+        checksum: "template-checksum",
+        storage_ref: "s3://templates/constitution"
+      }
+    ]
+  });
+
+    const overlays: OverlayReference[] = [{ id: "tenant-pack", version: "1.2.0" }];
+    const result = await createWorkflowRun(client, {
+      workflowKey: baseGraph.id,
+      workflowVersion: baseGraph.version,
+      subjectOrgId: "00000000-0000-0000-0000-000000000111",
+      tenantOrgId: TENANT_ID,
+      overlays
+    });
+
+    assert.equal(result.run.workflow_def_id, WORKFLOW_DEF_ID);
+    assert.ok(result.run.merged_workflow_snapshot);
+    assert.deepEqual(result.lockfile.workflowDef, {
+      id: baseGraph.id,
+      version: baseGraph.version,
+      checksum: "wf-checksum"
+    });
+    assert.equal(result.lockfile.overlays.length, 1);
+    assert.equal(result.lockfile.overlays[0]?.id, "tenant-pack");
+    assert.equal(result.lockfile.rules["rule.deadline"].sources[0]?.fingerprint, "fingerprint-1");
+
+    const storedRuns = getTableRows("workflow_runs");
+    assert.equal(storedRuns.length, 1);
+    assert.deepEqual(storedRuns[0]?.merged_workflow_snapshot, result.lockfile);
+  });
+});
+
+async function withWorkspaceModules<T>(callback: () => Promise<T>): Promise<T> {
+  const tempRoot = mkdtempSync(join(tmpdir(), "portal-engine-stub-"));
+  const scopeRoot = join(tempRoot, "@airnub");
+  const engineRoot = join(scopeRoot, "engine");
+  const typesRoot = join(scopeRoot, "types");
+  mkdirSync(engineRoot, { recursive: true });
+  mkdirSync(typesRoot, { recursive: true });
+
+  const repoRoot = fileURLToPath(new URL("../../../../../", import.meta.url));
+  const engineSrc = join(repoRoot, "packages/engine/src/engine.ts");
+  const engineTypesSrc = join(repoRoot, "packages/engine/src/types.ts");
+  const supabaseTypesSrc = join(repoRoot, "packages/types/src/supabase.ts");
+
+  writeFileSync(
+    join(engineRoot, "package.json"),
+    JSON.stringify({
+      name: "@airnub/engine",
+      type: "module",
+      exports: {
+        "./engine": "./engine.js",
+        "./types": "./types.js"
+      }
+    })
+  );
+  writeFileSync(join(engineRoot, "engine.js"), `export * from ${JSON.stringify(pathToFileURL(engineSrc).href)};`);
+  writeFileSync(join(engineRoot, "types.js"), `export * from ${JSON.stringify(pathToFileURL(engineTypesSrc).href)};`);
+
+  writeFileSync(
+    join(typesRoot, "package.json"),
+    JSON.stringify({
+      name: "@airnub/types",
+      type: "module",
+      exports: {
+        "./supabase": "./supabase.js"
+      }
+    })
+  );
+  writeFileSync(join(typesRoot, "supabase.js"), `export * from ${JSON.stringify(pathToFileURL(supabaseTypesSrc).href)};`);
+
+  const previousNodePath = process.env.NODE_PATH;
+  process.env.NODE_PATH = tempRoot + (previousNodePath ? `${delimiter}${previousNodePath}` : "");
+  Module._initPaths();
+
+  try {
+    return await callback();
+  } finally {
+    process.env.NODE_PATH = previousNodePath;
+    Module._initPaths();
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+}

--- a/apps/portal/src/server/workflow-runs.ts
+++ b/apps/portal/src/server/workflow-runs.ts
@@ -1,0 +1,268 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { materialize } from "@airnub/engine/engine";
+import type {
+  MaterializeContext,
+  MaterializeDataSource,
+  MaterializedRun,
+  OverlayPatch,
+  OverlayReference,
+  RuleSourceSnapshot,
+  RuleVersionRecord,
+  RuleVersionSelector,
+  TemplateVersionRecord,
+  TemplateVersionSelector,
+  WorkflowDefinitionVersionRecord,
+  WorkflowDSL,
+  WorkflowLockfile,
+  WorkflowOverlayVersionRecord
+} from "@airnub/engine/types";
+import type { Database, Json } from "@airnub/types/supabase";
+
+export type CreateWorkflowRunInput = {
+  workflowKey: string;
+  workflowVersion: string;
+  subjectOrgId: string;
+  tenantOrgId: string;
+  overlays?: OverlayReference[];
+  engagerOrgId?: string;
+  createdByUserId?: string;
+  status?: Database["public"]["Tables"]["workflow_runs"]["Row"]["status"];
+  orchestrationProvider?: string;
+  orchestrationWorkflowId?: string | null;
+};
+
+export type CreateWorkflowRunResult = {
+  run: Database["public"]["Tables"]["workflow_runs"]["Row"];
+  lockfile: WorkflowLockfile;
+  materialized: MaterializedRun;
+};
+
+export async function createWorkflowRun(
+  client: SupabaseClient<Database>,
+  input: CreateWorkflowRunInput,
+  context?: MaterializeContext
+): Promise<CreateWorkflowRunResult> {
+  const overlays = input.overlays ?? [];
+  const materializeContext = context ?? createSupabaseMaterializeContext(client, input.tenantOrgId);
+  const materialized = await materialize(
+    input.workflowKey,
+    input.workflowVersion,
+    overlays,
+    materializeContext
+  );
+
+  const insertPayload: Database["public"]["Tables"]["workflow_runs"]["Insert"] = {
+    workflow_def_id: materialized.definitionVersion.workflowDefId,
+    subject_org_id: input.subjectOrgId,
+    tenant_org_id: input.tenantOrgId,
+    engager_org_id: input.engagerOrgId ?? null,
+    created_by_user_id: input.createdByUserId ?? null,
+    status: input.status ?? "active",
+    orchestration_provider: input.orchestrationProvider ?? "none",
+    orchestration_workflow_id: input.orchestrationWorkflowId ?? null,
+    merged_workflow_snapshot: materialized.lockfile as Json
+  };
+
+  const { data, error } = await client
+    .from("workflow_runs")
+    .insert(insertPayload)
+    .select()
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to create workflow run: ${error.message}`);
+  }
+  if (!data) {
+    throw new Error("Workflow run insert returned no data");
+  }
+
+  return { run: data, lockfile: materialized.lockfile, materialized } satisfies CreateWorkflowRunResult;
+}
+
+function createSupabaseMaterializeContext(
+  client: SupabaseClient<Database>,
+  tenantOrgId: string
+): MaterializeContext {
+  const dataSource: MaterializeDataSource = {
+    async getWorkflowDefinitionVersion(defKey, version) {
+      const { data: definition, error: defError } = await client
+        .from("workflow_defs")
+        .select("id, key")
+        .eq("key", defKey)
+        .maybeSingle();
+      if (defError) {
+        throw new Error(`Unable to load workflow definition ${defKey}: ${defError.message}`);
+      }
+      if (!definition) {
+        return undefined;
+      }
+
+      const { data: versionRow, error: versionError } = await client
+        .from("workflow_def_versions")
+        .select("id, workflow_def_id, version, checksum, graph_jsonb, rule_ranges, template_ranges")
+        .eq("workflow_def_id", definition.id)
+        .eq("version", version)
+        .eq("tenant_org_id", tenantOrgId)
+        .maybeSingle();
+
+      if (versionError) {
+        throw new Error(`Unable to load workflow definition version ${defKey}@${version}: ${versionError.message}`);
+      }
+      if (!versionRow) {
+        return undefined;
+      }
+
+      return {
+        id: versionRow.id,
+        workflowDefId: versionRow.workflow_def_id,
+        workflowKey: defKey,
+        version: versionRow.version,
+        checksum: versionRow.checksum,
+        graph: versionRow.graph_jsonb as WorkflowDSL,
+        ruleBindings: normaliseSelectors(versionRow.rule_ranges) as Record<string, RuleVersionSelector>,
+        templateBindings: normaliseSelectors(versionRow.template_ranges) as Record<string, TemplateVersionSelector>
+      } satisfies WorkflowDefinitionVersionRecord;
+    },
+    async getOverlayVersion(ref) {
+      const { data: row, error } = await client
+        .from("workflow_pack_versions")
+        .select("id, pack_id, version, checksum, overlay_jsonb")
+        .eq("tenant_org_id", tenantOrgId)
+        .eq("pack_id", ref.id)
+        .eq("version", ref.version)
+        .maybeSingle();
+      if (error) {
+        throw new Error(`Unable to load overlay ${ref.id}@${ref.version}: ${error.message}`);
+      }
+      if (!row) {
+        return undefined;
+      }
+
+      const patch = normaliseOverlayPatch(row.overlay_jsonb, row.pack_id);
+      return {
+        id: row.id,
+        overlayId: row.pack_id,
+        version: row.version,
+        checksum: row.checksum,
+        patch
+      } satisfies WorkflowOverlayVersionRecord;
+    },
+    async getRuleVersion(ruleId, selector) {
+      const version = resolveSelectorVersion(ruleId, selector);
+      const { data: row, error } = await client
+        .from("rule_versions")
+        .select("id, rule_id, version, checksum, sources")
+        .eq("tenant_org_id", tenantOrgId)
+        .eq("rule_id", ruleId)
+        .eq("version", version)
+        .maybeSingle();
+      if (error) {
+        throw new Error(`Unable to load rule ${ruleId}@${version}: ${error.message}`);
+      }
+      if (!row) {
+        return undefined;
+      }
+
+      return {
+        id: row.id,
+        ruleId: row.rule_id,
+        version: row.version,
+        checksum: row.checksum,
+        sources: normaliseRuleSources(row.sources)
+      } satisfies RuleVersionRecord;
+    },
+    async getTemplateVersion(templateId, selector) {
+      const version = resolveSelectorVersion(templateId, selector);
+      const { data: row, error } = await client
+        .from("template_versions")
+        .select("id, template_id, version, checksum")
+        .eq("tenant_org_id", tenantOrgId)
+        .eq("template_id", templateId)
+        .eq("version", version)
+        .maybeSingle();
+      if (error) {
+        throw new Error(`Unable to load template ${templateId}@${version}: ${error.message}`);
+      }
+      if (!row) {
+        return undefined;
+      }
+      return {
+        id: row.id,
+        templateId: row.template_id,
+        version: row.version,
+        checksum: row.checksum
+      } satisfies TemplateVersionRecord;
+    }
+  } satisfies MaterializeDataSource;
+
+  return { data: dataSource } satisfies MaterializeContext;
+}
+
+function normaliseSelectors(value: unknown): Record<string, RuleVersionSelector | TemplateVersionSelector> {
+  if (!value || typeof value !== "object") {
+    return {};
+  }
+  const entries = Object.entries(value as Record<string, unknown>);
+  return entries.reduce<Record<string, RuleVersionSelector | TemplateVersionSelector>>((acc, [key, raw]) => {
+    if (typeof raw === "string") {
+      acc[key] = raw;
+    } else if (raw && typeof raw === "object") {
+      const maybe = raw as { version?: unknown; range?: unknown };
+      if (typeof maybe.version === "string") {
+        acc[key] = { version: maybe.version };
+      } else if (typeof maybe.range === "string") {
+        acc[key] = { range: maybe.range };
+      }
+    }
+    return acc;
+  }, {});
+}
+
+function resolveSelectorVersion(id: string, selector: RuleVersionSelector | TemplateVersionSelector): string {
+  if (typeof selector === "string") {
+    return selector;
+  }
+  if (selector && typeof selector === "object" && typeof selector.version === "string") {
+    return selector.version;
+  }
+  throw new Error(`Unsupported version selector for ${id}`);
+}
+
+function normaliseOverlayPatch(value: unknown, fallbackSource: string): OverlayPatch {
+  if (value && typeof value === "object" && Array.isArray((value as OverlayPatch).operations)) {
+    const patch = value as OverlayPatch;
+    return {
+      operations: patch.operations,
+      source: patch.source ?? fallbackSource
+    } satisfies OverlayPatch;
+  }
+  if (Array.isArray(value)) {
+    return { operations: value as OverlayPatch["operations"], source: fallbackSource } satisfies OverlayPatch;
+  }
+  throw new Error("Overlay patch must be an array of operations");
+}
+
+function normaliseRuleSources(value: unknown): RuleSourceSnapshot[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") {
+        return undefined;
+      }
+      const record = entry as Record<string, unknown>;
+      const sourceKey = record.source_key ?? record.sourceKey;
+      const snapshotId = record.snapshot_id ?? record.snapshotId;
+      const fingerprint = record.fingerprint ?? record.hash ?? record.content_hash;
+      if (typeof sourceKey === "string" && typeof snapshotId === "string" && typeof fingerprint === "string") {
+        return {
+          sourceKey,
+          snapshotId,
+          fingerprint
+        } satisfies RuleSourceSnapshot;
+      }
+      return undefined;
+    })
+    .filter((item): item is RuleSourceSnapshot => Boolean(item));
+}

--- a/packages/engine/src/__tests__/materialize-lockfile.test.ts
+++ b/packages/engine/src/__tests__/materialize-lockfile.test.ts
@@ -1,0 +1,203 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+import {
+  materialize,
+  verify
+} from "../engine.js";
+import type {
+  MaterializeContext,
+  MaterializeDataSource,
+  OverlayPatch,
+  OverlayReference,
+  RuleVersionRecord,
+  TemplateVersionRecord,
+  WorkflowDefinitionVersionRecord,
+  WorkflowDSL,
+  WorkflowLockfile,
+  WorkflowOverlayVersionRecord
+} from "../types.js";
+
+const baseWorkflow: WorkflowDSL = {
+  id: "setup-nonprofit",
+  version: "1.0.0",
+  title: "Demo",
+  steps: [
+    {
+      id: "base-step",
+      kind: "info",
+      title: "Collect documents",
+      verify: [{ id: "rule.deadline" }]
+    }
+  ]
+};
+
+const ruleVersion: RuleVersionRecord = {
+  id: "rule-version-1",
+  ruleId: "rule.deadline",
+  version: "2.0.0",
+  checksum: "rule-checksum",
+  sources: [
+    { sourceKey: "cro_open_services", snapshotId: "snapshot-1", fingerprint: "fp-cro" }
+  ]
+};
+
+const templateVersion: TemplateVersionRecord = {
+  id: "template-version-1",
+  templateId: "constitution",
+  version: "3.1.0",
+  checksum: "template-checksum"
+};
+
+const overlayPatch: OverlayPatch = {
+  operations: [
+    {
+      op: "add",
+      path: "/steps/-",
+      value: { id: "overlay-step", kind: "info", title: "Tenant introduction" }
+    }
+  ],
+  source: "tenant-pack"
+};
+
+const definitionVersion: WorkflowDefinitionVersionRecord = {
+  id: "definition-version-1",
+  workflowDefId: "workflow-def-row-1",
+  workflowKey: baseWorkflow.id,
+  version: baseWorkflow.version,
+  checksum: "definition-checksum",
+  graph: baseWorkflow,
+  ruleBindings: { "rule.deadline": { version: "2.0.0" } },
+  templateBindings: { constitution: { version: "3.1.0" } }
+};
+
+const overlayVersion: WorkflowOverlayVersionRecord = {
+  id: "overlay-version-1",
+  overlayId: "tenant-pack",
+  version: "1.2.0",
+  checksum: "overlay-checksum",
+  patch: overlayPatch
+};
+
+const stubDataSource: MaterializeDataSource = {
+  async getWorkflowDefinitionVersion(defId: string, version: string) {
+    if (defId === baseWorkflow.id && version === baseWorkflow.version) {
+      return definitionVersion;
+    }
+    return undefined;
+  },
+  async getOverlayVersion(ref: OverlayReference) {
+    if (ref.id === overlayVersion.overlayId && ref.version === overlayVersion.version) {
+      return overlayVersion;
+    }
+    return undefined;
+  },
+  async getRuleVersion(ruleId: string, _selector: unknown) {
+    return ruleId === ruleVersion.ruleId ? ruleVersion : undefined;
+  },
+  async getTemplateVersion(templateId: string, _selector: unknown) {
+    return templateId === templateVersion.templateId ? templateVersion : undefined;
+  }
+};
+
+test("materialize produces a lockfile with checksums and overlays", async () => {
+  const context: MaterializeContext = { data: stubDataSource };
+  const overlays: OverlayReference[] = [{ id: "tenant-pack", version: "1.2.0" }];
+  const result = await materialize(baseWorkflow.id, baseWorkflow.version, overlays, context);
+
+  assert.equal(result.lockfile.workflowDef.id, baseWorkflow.id);
+  assert.equal(result.lockfile.workflowDef.version, baseWorkflow.version);
+  assert.equal(result.lockfile.workflowDef.checksum, "definition-checksum");
+  assert.deepEqual(result.lockfile.overlays, [
+    { id: "tenant-pack", version: "1.2.0", checksum: "overlay-checksum" }
+  ]);
+  assert.deepEqual(result.lockfile.rules["rule.deadline"], {
+    id: "rule.deadline",
+    version: "2.0.0",
+    checksum: "rule-checksum",
+    sources: ruleVersion.sources
+  });
+  assert.deepEqual(result.lockfile.templates.constitution, {
+    id: "constitution",
+    version: "3.1.0",
+    checksum: "template-checksum"
+  });
+  assert.ok(result.steps.find((step) => step.id === "overlay-step"));
+});
+
+function computeFingerprint(records: Record<string, unknown>[]): string {
+  const canonical = records
+    .map((record) =>
+      JSON.stringify(record, (_key, value) => {
+        if (Array.isArray(value)) {
+          return value;
+        }
+        if (value && typeof value === "object") {
+          const sorted = Object.keys(value as Record<string, unknown>).sort();
+          return sorted.reduce<Record<string, unknown>>((acc, key) => {
+            acc[key] = (value as Record<string, unknown>)[key];
+            return acc;
+          }, {});
+        }
+        return value;
+      })
+    )
+    .sort()
+    .join("|");
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+test("verify recomputes fingerprints and flags stale sources", async () => {
+  const matchingRecords = [{ id: 1, name: "A" }];
+  const staleRecords = [{ id: 2, name: "B" }];
+  const lockfile: WorkflowLockfile = {
+    workflowDef: { id: "wf", version: "1.0.0", checksum: "wf-checksum" },
+    overlays: [],
+    rules: {
+      "rule.deadline": {
+        id: "rule.deadline",
+        version: "2.0.0",
+        checksum: "rule-checksum",
+        sources: [
+          {
+            sourceKey: "cro_open_services",
+            snapshotId: "snapshot-1",
+            fingerprint: computeFingerprint(matchingRecords)
+          },
+          {
+            sourceKey: "charities_ckan",
+            snapshotId: "snapshot-2",
+            fingerprint: "stale-fingerprint"
+          }
+        ]
+      }
+    },
+    templates: {}
+  };
+
+  const result = await verify(lockfile, {
+    fetchSourceRecords: async (sourceKey) => {
+      if (sourceKey === "cro_open_services") {
+        return matchingRecords;
+      }
+      if (sourceKey === "charities_ckan") {
+        return staleRecords;
+      }
+      throw new Error(`Unexpected source ${sourceKey}`);
+    },
+    buildFingerprint: computeFingerprint,
+    now: () => new Date("2024-01-02T03:04:05Z")
+  });
+
+  assert.equal(result.verifiedAt, "2024-01-02T03:04:05.000Z");
+  const rule = result.rules["rule.deadline"];
+  assert.equal(rule.status, "stale");
+  assert.equal(rule.sources.length, 2);
+  const [first, second] = rule.sources;
+  assert.equal(first.matches, true);
+  assert.equal(first.observedFingerprint, first.expectedFingerprint);
+  assert.equal(first.recordCount, 1);
+  assert.deepEqual(first.sample, matchingRecords);
+  assert.equal(second.matches, false);
+  assert.notEqual(second.observedFingerprint, second.expectedFingerprint);
+});

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -1,16 +1,27 @@
-import jsonPatch, { type Operation } from "fast-json-patch";
+import { createHash } from "node:crypto";
+import jsonPatch from "fast-json-patch";
 import {
-  WorkflowDSL,
+  type MaterializeContext,
+  type MaterializedRun,
+  type MaterializeDataSource,
+  type OverlayPatch,
+  type OverlayReference,
+  type RuleSourceSnapshot,
+  type RuleVersionRecord,
+  type RuleVerificationEvidence,
+  type SourceRecord,
   StepDef,
   type StepExecution,
+  type TemplateVersionRecord,
   type WebhookStepExecution,
-  type WebsocketStepExecution
+  type WebsocketStepExecution,
+  type WorkflowDefinitionVersionRecord,
+  WorkflowDSL,
+  type WorkflowLockfile,
+  type WorkflowOverlayVersionRecord,
+  type VerificationResult,
+  type VerificationSourceEvidence
 } from "./types.js";
-
-export type OverlayPatch = {
-  operations: Operation[];
-  source?: string;
-};
 
 export interface MaterializeOptions {
   overlays?: OverlayPatch[];
@@ -185,4 +196,207 @@ export function materializeWorkflow(dsl: WorkflowDSL, options: MaterializeOption
 
 export function materializeSteps(dsl: WorkflowDSL, overlays: OverlayPatch[] = []): StepDef[] {
   return materializeWorkflow(dsl, { overlays }).steps;
+}
+
+function ensure<T>(value: T | null | undefined, message: string): T {
+  if (value === null || value === undefined) {
+    throw new Error(message);
+  }
+  return value;
+}
+
+function cloneRuleSource(source: RuleSourceSnapshot): RuleSourceSnapshot {
+  return {
+    sourceKey: source.sourceKey,
+    snapshotId: source.snapshotId,
+    fingerprint: source.fingerprint
+  } satisfies RuleSourceSnapshot;
+}
+
+function normaliseOverlayPatch(record: WorkflowOverlayVersionRecord): OverlayPatch {
+  const operations = record.patch.operations.map((operation) => ({ ...operation }));
+  if (record.patch.source) {
+    return { operations, source: record.patch.source };
+  }
+  return { operations, source: record.overlayId };
+}
+
+function requireDataSource(context: MaterializeContext | undefined): MaterializeDataSource {
+  if (!context?.data) {
+    throw new Error("materialize requires a data source");
+  }
+  return context.data;
+}
+
+export async function materialize(
+  defId: string,
+  defVersion: string,
+  overlays: OverlayReference[] = [],
+  context?: MaterializeContext
+): Promise<MaterializedRun> {
+  const dataSource = requireDataSource(context);
+
+  const definition = ensure(
+    await dataSource.getWorkflowDefinitionVersion(defId, defVersion),
+    `Workflow definition ${defId}@${defVersion} not found`
+  );
+
+  const overlayVersions = await Promise.all(
+    overlays.map(async (ref) =>
+      ensure(
+        await dataSource.getOverlayVersion(ref),
+        `Overlay ${ref.id}@${ref.version} not found`
+      )
+    )
+  );
+
+  const merged = materializeWorkflow(definition.graph, {
+    overlays: overlayVersions.map((record) => normaliseOverlayPatch(record))
+  });
+
+  const ruleVersionEntries = await Promise.all(
+    Object.entries(definition.ruleBindings ?? {}).map(async ([ruleId, selector]) => {
+      const version = ensure(
+        await dataSource.getRuleVersion(ruleId, selector),
+        `Rule ${ruleId} version matching selector not found`
+      );
+      return [ruleId, version] as const;
+    })
+  );
+  const ruleVersions = Object.fromEntries(ruleVersionEntries) as Record<string, RuleVersionRecord>;
+
+  const templateVersionEntries = await Promise.all(
+    Object.entries(definition.templateBindings ?? {}).map(async ([templateId, selector]) => {
+      const version = ensure(
+        await dataSource.getTemplateVersion(templateId, selector),
+        `Template ${templateId} version matching selector not found`
+      );
+      return [templateId, version] as const;
+    })
+  );
+  const templateVersions = Object.fromEntries(templateVersionEntries) as Record<string, TemplateVersionRecord>;
+
+  const lockfile: WorkflowLockfile = {
+    workflowDef: {
+      id: definition.workflowKey,
+      version: definition.version,
+      checksum: definition.checksum
+    },
+    overlays: overlayVersions.map((overlay) => ({
+      id: overlay.overlayId,
+      version: overlay.version,
+      checksum: overlay.checksum
+    })),
+    rules: Object.fromEntries(
+      Object.entries(ruleVersions).map(([ruleId, version]) => [
+        ruleId,
+        {
+          id: ruleId,
+          version: version.version,
+          checksum: version.checksum,
+          sources: version.sources.map(cloneRuleSource)
+        }
+      ])
+    ),
+    templates: Object.fromEntries(
+      Object.entries(templateVersions).map(([templateId, version]) => [
+        templateId,
+        {
+          id: templateId,
+          version: version.version,
+          checksum: version.checksum
+        }
+      ])
+    )
+  } satisfies WorkflowLockfile;
+
+  return {
+    workflow: merged.workflow,
+    steps: merged.steps,
+    warnings: merged.warnings,
+    lockfile,
+    definitionVersion: definition,
+    overlayVersions,
+    ruleVersions,
+    templateVersions
+  } satisfies MaterializedRun;
+}
+
+function canonicalStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, input) => {
+    if (Array.isArray(input)) {
+      return input;
+    }
+    if (input && typeof input === "object") {
+      const sortedKeys = Object.keys(input as Record<string, unknown>).sort();
+      return sortedKeys.reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = (input as Record<string, unknown>)[key];
+        return acc;
+      }, {});
+    }
+    return input;
+  });
+}
+
+function defaultFingerprint(records: SourceRecord[]): string {
+  const canonical = records.map((record) => canonicalStringify(record)).sort().join("|");
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+export interface VerifyOptions {
+  fetchSourceRecords: (sourceKey: string) => Promise<SourceRecord[]>;
+  buildFingerprint?: (records: SourceRecord[]) => string;
+  now?: () => Date;
+}
+
+export async function verify(
+  lockfile: WorkflowLockfile,
+  options: VerifyOptions
+): Promise<VerificationResult> {
+  if (!options?.fetchSourceRecords) {
+    throw new Error("verify requires a fetchSourceRecords implementation");
+  }
+
+  const clock = options.now ?? (() => new Date());
+  const verifiedAt = clock().toISOString();
+  const fingerprint = options.buildFingerprint ?? defaultFingerprint;
+
+  const rules = await Promise.all(
+    Object.entries(lockfile.rules).map(async ([ruleId, rule]) => {
+      const sources: VerificationSourceEvidence[] = await Promise.all(
+        rule.sources.map(async (source) => {
+          const records = await options.fetchSourceRecords(source.sourceKey);
+          const observedFingerprint = fingerprint(records);
+          const matches = observedFingerprint === source.fingerprint;
+          const sample = records.slice(0, 5).map((record) => structuredClone(record));
+          return {
+            sourceKey: source.sourceKey,
+            snapshotId: source.snapshotId,
+            expectedFingerprint: source.fingerprint,
+            observedFingerprint,
+            matches,
+            fetchedAt: verifiedAt,
+            recordCount: records.length,
+            sample
+          } satisfies VerificationSourceEvidence;
+        })
+      );
+
+      const stale = sources.some((entry) => !entry.matches);
+      const evidence: RuleVerificationEvidence = {
+        ruleId,
+        version: rule.version,
+        checksum: rule.checksum,
+        verifiedAt,
+        status: stale ? "stale" : "verified",
+        sources
+      } satisfies RuleVerificationEvidence;
+      return [ruleId, evidence] as const;
+    })
+  );
+
+  return {
+    verifiedAt,
+    rules: Object.fromEntries(rules)
+  } satisfies VerificationResult;
 }

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -1,3 +1,5 @@
+import type { Operation } from "fast-json-patch";
+
 export type NodeKind = "question" | "info" | "action" | "upload" | "doc.generate" | "tool.call" | "verify" | "schedule" | "review";
 export type RuleRef = { id: string };
 export type ManualStepExecution = {
@@ -90,4 +92,148 @@ export type WorkflowDSL = {
   steps: StepDef[];
   edges?: WorkflowEdge[];
   metadata?: Record<string, unknown>;
+};
+
+export type OverlayPatch = {
+  operations: Operation[];
+  source?: string;
+};
+
+export type RuleVersionSelector = string | { version: string } | { range: string };
+
+export type TemplateVersionSelector = string | { version: string } | { range: string };
+
+export type RuleSourceSnapshot = {
+  sourceKey: string;
+  snapshotId: string;
+  fingerprint: string;
+};
+
+export type RuleVersionRecord = {
+  id: string;
+  ruleId: string;
+  version: string;
+  checksum: string;
+  sources: RuleSourceSnapshot[];
+};
+
+export type TemplateVersionRecord = {
+  id: string;
+  templateId: string;
+  version: string;
+  checksum: string;
+};
+
+export type OverlayReference = {
+  id: string;
+  version: string;
+};
+
+export type WorkflowOverlayVersionRecord = {
+  id: string;
+  overlayId: string;
+  version: string;
+  checksum: string;
+  patch: OverlayPatch;
+};
+
+export type WorkflowDefinitionVersionRecord = {
+  id: string;
+  workflowDefId: string;
+  workflowKey: string;
+  version: string;
+  checksum: string;
+  graph: WorkflowDSL;
+  ruleBindings: Record<string, RuleVersionSelector>;
+  templateBindings: Record<string, TemplateVersionSelector>;
+};
+
+export type WorkflowLockfileWorkflow = {
+  id: string;
+  version: string;
+  checksum: string;
+};
+
+export type WorkflowLockfileOverlay = {
+  id: string;
+  version: string;
+  checksum: string;
+};
+
+export type WorkflowLockfileRule = {
+  id: string;
+  version: string;
+  checksum: string;
+  sources: RuleSourceSnapshot[];
+};
+
+export type WorkflowLockfileTemplate = {
+  id: string;
+  version: string;
+  checksum: string;
+};
+
+export type WorkflowLockfile = {
+  workflowDef: WorkflowLockfileWorkflow;
+  overlays: WorkflowLockfileOverlay[];
+  rules: Record<string, WorkflowLockfileRule>;
+  templates: Record<string, WorkflowLockfileTemplate>;
+};
+
+export type MaterializeDataSource = {
+  getWorkflowDefinitionVersion(
+    defId: string,
+    version: string
+  ): Promise<WorkflowDefinitionVersionRecord | undefined>;
+  getOverlayVersion(ref: OverlayReference): Promise<WorkflowOverlayVersionRecord | undefined>;
+  getRuleVersion(
+    ruleId: string,
+    selector: RuleVersionSelector
+  ): Promise<RuleVersionRecord | undefined>;
+  getTemplateVersion(
+    templateId: string,
+    selector: TemplateVersionSelector
+  ): Promise<TemplateVersionRecord | undefined>;
+};
+
+export type MaterializeContext = {
+  data: MaterializeDataSource;
+};
+
+export type MaterializedRun = {
+  workflow: WorkflowDSL;
+  steps: StepDef[];
+  warnings: string[];
+  lockfile: WorkflowLockfile;
+  definitionVersion: WorkflowDefinitionVersionRecord;
+  overlayVersions: WorkflowOverlayVersionRecord[];
+  ruleVersions: Record<string, RuleVersionRecord>;
+  templateVersions: Record<string, TemplateVersionRecord>;
+};
+
+export type SourceRecord = Record<string, unknown>;
+
+export type VerificationSourceEvidence = {
+  sourceKey: string;
+  snapshotId: string;
+  expectedFingerprint: string;
+  observedFingerprint: string;
+  matches: boolean;
+  fetchedAt: string;
+  recordCount: number;
+  sample: SourceRecord[];
+};
+
+export type RuleVerificationEvidence = {
+  ruleId: string;
+  version: string;
+  checksum: string;
+  verifiedAt: string;
+  status: "verified" | "stale";
+  sources: VerificationSourceEvidence[];
+};
+
+export type VerificationResult = {
+  verifiedAt: string;
+  rules: Record<string, RuleVerificationEvidence>;
 };


### PR DESCRIPTION
## Summary
- extend engine types and APIs with lockfile data, materialization via data providers, and verification helpers
- add tests covering lockfile generation, verification, and portal workflow run snapshot persistence using a Supabase context
- update freshness rule verification to consume engine verification evidence and adjust portal test wiring

## Testing
- pnpm exec tsx --test packages/engine/src/__tests__/*.test.ts
- pnpm --filter @airnub/portal test

------
https://chatgpt.com/codex/tasks/task_e_68e03a7337908324ba87348eabb522bd