### PR TITLE
feat(portal): support semver range selectors in workflow materialization

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -27,7 +27,8 @@
     "next": "15.0.0",
     "next-intl": "^3.13.3",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "semver": "^7.6.3"
   },
   "devDependencies": {
     "@types/negotiator": "^0.6.3",


### PR DESCRIPTION
## Summary
- add the semver runtime dependency so the portal server can evaluate selector ranges
- resolve rule and template selectors through semver-aware lookup with helpful errors when no version matches
- cover range-based selectors in workflow run tests to confirm the lockfile pins the expected versions

## Testing
- pnpm --filter @airnub/portal test

------
https://chatgpt.com/codex/tasks/task_e_68e040487f8c8324bd7a4b0611a0c3ce