### PR TITLE
Document SOC 2 control requirements across specs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,8 @@
 - **ADR-0003: White-Label Multi-Tenant Architecture** — `../adr/0003-white-label-multi-tenant-architecture.md`
 - **ADR-0002: Stripe Billing Scaffold** — `../adr/0002-billing-stripe.md`
 
+> **SOC 2 Compliance:** FreshComply must maintain SOC 2 Type II readiness. See `specs/fresh-comply-spec.md` §11.1 for the platform control library and `specs/admin-app-spec.md` §9 for admin surface obligations. Reference these sections when adding or modifying security/audit functionality.
+
 ## Getting Started
 - **Local Development** — `getting-started/local-development.md`
 - **Codespaces** — `getting-started/codespaces.md`

--- a/docs/specs/admin-app-spec.md
+++ b/docs/specs/admin-app-spec.md
@@ -16,7 +16,7 @@
 - **Auth:** Supabase Auth via `@supabase/ssr`. Middleware negotiates locale, enforces authentication, and redirects non-admins to login.
 - **RBAC Utilities:** `src/lib/rbac.ts` exposes helpers for step editing and second-approval checks.
 - **Audit Layer:** Every API mutation records `admin_action_id`, reason codes, diff snapshots, and actor metadata.
-- **Security:** CSRF protection, per-admin rate limits on high-risk routes, redaction of PII in logs.
+- **Security:** CSRF protection, per-admin rate limits on high-risk routes, redaction of PII in logs; adheres to [Product Spec §11.1 SOC 2 controls](./fresh-comply-spec.md#soc-2-compliance-requirements).
 
 ## 3. App Structure
 ```
@@ -84,3 +84,14 @@ pnpm run dev:worker  # Temporal worker bundle
 pnpm run dev:admin   # Admin app on http://localhost:3100
 ```
 Keep admin tooling isolated from customer portal; do not link to Temporal Web UI from customer surfaces.
+
+## 9. SOC 2 Control Coverage
+
+The admin app is a primary surface for SOC 2 evidence collection. It must:
+
+- **Enforce Controlled Changes:** All privileged actions require authenticated admins, role checks, reason codes, and (where specified) two-person approval to satisfy change-management controls.
+- **Guarantee Audit Integrity:** Persist `admin_actions` and related log entries in append-only stores with hashes/diffs so auditors can trace sample selections back to immutable evidence.
+- **Surface Access Reviews:** Provide exports/reporting for quarterly access reviews (users, roles, step type editors, Temporal operators) aligned with the joiner/mover/leaver workflow defined in [Product Spec §11.1](./fresh-comply-spec.md#soc-2-compliance-requirements).
+- **Track Monitoring Events:** Bubble queue health, watcher drift, and incident annotations into admin dashboards so monitoring/incident-response evidence is reviewable.
+- **Link Vendor Decisions:** Store subprocessor approvals/attestations and make them discoverable for SOC 2 vendor-management samples.
+- **Support Evidence Packaging:** Offer filtered exports (CSV/JSON) tagged with control IDs to streamline quarterly readiness packets.

--- a/docs/specs/fresh-comply-spec.md
+++ b/docs/specs/fresh-comply-spec.md
@@ -198,9 +198,22 @@ These are integrated as:
 * **Retention & Deletion:** soft‑delete → scheduled hard‑delete; policy tables per entity; user‑initiated exports (ZIP/JSON/CSV).
 * **DPA:** standard processor DPA with annexes; **Subprocessors registry** & change‑notice policy; SCC annex placeholders.
 * **Records:** `docs/LEGAL/ROPA.yaml` maintained; admin UI read‑only later.
-* **Security:** TLS; encryption at rest; least‑privilege RBAC; admin action audit; secrets in vault; Temporal workers read via service credentials; workflow code never touches raw secrets; session via `@supabase/ssr`.
+* **Security:** TLS; encryption at rest; least‑privilege RBAC; admin action audit; secrets in vault; Temporal workers read via service credentials; workflow code never touches raw secrets; session via `@supabase/ssr`. (See [§11.1 SOC 2 Compliance Requirements](./fresh-comply-spec.md#soc-2-compliance-requirements) for the canonical control set.)
 * **Breach Response:** defined in `INCIDENT‑RESPONSE.md` (72‑hour notification flow).
 * **Consent:** Cookie banner with categories; server‑gated scripts; consent stored in cookie + DB.
+
+### SOC 2 Compliance Requirements
+
+FreshComply must maintain **SOC 2 Type II** readiness across the Trust Services Criteria in scope (Security, Availability, Confidentiality). The platform team owns the control library and evidence plan.
+
+* **Control Ownership:** Map every policy/technical control to a control ID with owner, automation status, and evidence cadence; publish in `docs/LEGAL/soc2-control-matrix.md` (or successor) and keep it versioned.
+* **Change Management:** All production-impacting changes flow through Git-based review with two-person approval on protected branches; emergency fixes require documented post-mortem within 24 hours.
+* **Access Management:** Quarterly access reviews for Supabase, Temporal, CI/CD, and third-party SaaS; enforce SSO/MFA for admins; document joiner/mover/leaver workflows with timestamps and approvers.
+* **Audit Logging & Retention:** Centralise structured logs for admin/API actions, Temporal events, and infrastructure via append-only storage retained ≥ 1 year; ensure logs are immutable and queryable for auditors.
+* **Monitoring & Incident Response:** Continuous monitoring for control failures (authentication anomalies, job queue health, watcher drift) with PagerDuty or equivalent alerts; incident runbooks include evidence capture for audits.
+* **Vendor & Subprocessor Oversight:** Maintain current subprocessor inventory with SOC 2/ISO certificates or risk assessments; document annual review outcomes and remediation plans.
+* **Evidence Management:** Store audit evidence (screenshots, exports, reports) in an access-controlled repository with tagging by control ID; prepare quarterly readiness packets.
+* **Cross-Team Alignment:** Coordinate with Admin App requirements in [Admin Spec §11](./admin-app-spec.md#11-security-logging-and-audit) to ensure UI workflows capture approvals, justifications, and log integrity needed for SOC 2 sampling.
 
 ---
 
@@ -253,7 +266,7 @@ Tables: organisations, users, memberships, engagements, workflow_defs, workflow_
 * **A11y:** Pa11y + axe on home, run, board; keyboard e2e.
 * **Contrast:** token checker script for WCAG AA thresholds.
 * **Build:** ensure i18n message code‑split; bundle size guard.
-* **Security:** basic auth route tests; RLS verification queries in CI.
+* **Security:** basic auth route tests; RLS verification queries in CI. (Align with [SOC 2 Compliance Requirements](./fresh-comply-spec.md#soc-2-compliance-requirements) when extending coverage.)
 
 ---
 

--- a/docs/specs/fresh_comply_admin_app_spec_v_2025_10_03.md
+++ b/docs/specs/fresh_comply_admin_app_spec_v_2025_10_03.md
@@ -129,10 +129,19 @@ legal_holds(id, subject_kind, subject_id, reason, created_at, released_at)
 
 ## 11) Security, Logging, and Audit
 
-- **AuthN:** Supabase with `@supabase/ssr`; optional SSO later.  
-- **AuthZ:** server-side guards; actions behind **POST** with CSRF protection; rate limiting.  
-- **Audit:** all admin actions write to `admin_actions` and `audit_log` (actor, target, diff preview).  
+- **AuthN:** Supabase with `@supabase/ssr`; optional SSO later; aligns with SOC 2 access controls in [Product Spec §11.1](./fresh-comply-spec.md#soc-2-compliance-requirements).
+- **AuthZ:** server-side guards; actions behind **POST** with CSRF protection; rate limiting; reason codes + two-person approval enforce change-management controls.
+- **Audit:** all admin actions write to `admin_actions` and `audit_log` (actor, target, diff preview) with append-only retention ≥ 1 year to satisfy SOC 2 audit sampling.
 - **PII Redaction:** logs use stable IDs; payload redaction in server logs.
+- **Evidence Exports:** provide CSV/JSON exports tagged with control IDs for quarterly readiness packets.
+
+### SOC 2 Control Coverage (Admin App)
+
+- **Access Reviews:** dashboards + exports for quarterly user/role review, including joiner/mover/leaver history.
+- **Monitoring Hooks:** expose queue health, watcher drift, and incident annotations so monitoring controls are reviewable.
+- **Vendor Oversight:** store subprocessor attestations and approval history for SOC 2 vendor-management evidence.
+- **Change Approvals:** ensure privileged workflows capture justification, approver, timestamp, and linked change tickets.
+- **Evidence Repository Integration:** API endpoints to push signed evidence bundles into the central repository referenced in Product Spec §11.1.
 
 ---
 

--- a/docs/specs/fresh_comply_consolidated_requirements_spec_v_2025_10_03.md
+++ b/docs/specs/fresh_comply_consolidated_requirements_spec_v_2025_10_03.md
@@ -53,7 +53,7 @@
 
 - **Entities:** User, Organisation, Membership, **Engagement** (Org A↔Org X), WorkflowDef, WorkflowRun, Step/Task, Document, Rule, Verification, Notification, AuditLog, CalendarEvent.
 - **RLS policy:** A **WorkflowRun** is owned by **subject_org_id** (Company X) and is visible to its members and to Engagement members of **engager_org_id** (Company A) when Engagement is **active** and scoped to the run.
-- **Audit:** All actions record `{ actor_user_id, actor_org_id, on_behalf_of_org_id }`.
+- **Audit:** All actions record `{ actor_user_id, actor_org_id, on_behalf_of_org_id }` (evidence retained per [SOC 2 requirements](./fresh-comply-spec.md#soc-2-compliance-requirements)).
 
 ---
 


### PR DESCRIPTION
## Summary
- add SOC 2 control requirements to the consolidated product spec and cross-link existing security guidance
- extend the admin app specifications with SOC 2 evidence capture expectations and exports
- update the docs index and related architecture specs to highlight SOC 2 readiness obligations

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e043cbe39c8324a00e51b0e9aab38e