### PR TITLE
feat(notifications): support multiple realtime listeners

### DIFF
--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -3,5 +3,11 @@
   "version": "0.0.1",
   "private": true,
   "type": "module",
-  "main": "src/index.ts"
+  "main": "src/index.ts",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "vitest": "^2.1.3"
+  }
 }

--- a/packages/notifications/src/__tests__/realtime.test.ts
+++ b/packages/notifications/src/__tests__/realtime.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { publish, subscribe } from "../realtime";
+
+describe("realtime notifications", () => {
+  it("notifies every subscriber for a user", () => {
+    const userId = "user-123";
+    const notification = {
+      id: "notif-1",
+      userId,
+      title: "Test notification",
+      body: "This is only a test"
+    };
+
+    const firstListener = vi.fn();
+    const secondListener = vi.fn();
+
+    const unsubscribeFirst = subscribe(userId, firstListener);
+    const unsubscribeSecond = subscribe(userId, secondListener);
+
+    publish(notification);
+
+    expect(firstListener).toHaveBeenCalledWith(notification);
+    expect(secondListener).toHaveBeenCalledWith(notification);
+
+    unsubscribeFirst();
+    unsubscribeSecond();
+  });
+});

--- a/packages/notifications/src/realtime.ts
+++ b/packages/notifications/src/realtime.ts
@@ -6,13 +6,35 @@ type Notification = {
   readAt?: string;
 };
 
-const listeners = new Map<string, (notification: Notification) => void>();
+type Listener = (notification: Notification) => void;
 
-export function subscribe(userId: string, callback: (notification: Notification) => void) {
-  listeners.set(userId, callback);
+const listeners = new Map<string, Set<Listener>>();
+
+export function subscribe(userId: string, callback: Listener) {
+  let callbacks = listeners.get(userId);
+  if (!callbacks) {
+    callbacks = new Set();
+    listeners.set(userId, callbacks);
+  }
+
+  callbacks.add(callback);
+
+  return () => {
+    const currentCallbacks = listeners.get(userId);
+    currentCallbacks?.delete(callback);
+
+    if (currentCallbacks && currentCallbacks.size === 0) {
+      listeners.delete(userId);
+    }
+  };
 }
 
 export function publish(notification: Notification) {
-  const callback = listeners.get(notification.userId);
-  if (callback) callback(notification);
+  const callbacks = listeners.get(notification.userId);
+  if (!callbacks?.size) return;
+
+  const snapshot = Array.from(callbacks);
+  for (const callback of snapshot) {
+    callback(notification);
+  }
 }

--- a/packages/notifications/vitest.config.ts
+++ b/packages/notifications/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    coverage: {
+      reporter: ["text", "lcov"]
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- store a set of realtime notification listeners per user and expose an unsubscribe helper
- ensure publishing notifies every registered listener without mutation side effects
- add vitest configuration and a unit test covering multiple subscriptions for one user

## Testing
- pnpm --filter @airnub/notifications test

------
https://chatgpt.com/codex/tasks/task_e_68e0457fb4ac83248176b17785f60286