### PR TITLE
Fix devcontainer mounts for Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,8 +21,8 @@
   },
 
   "mounts": [
-    "type=cache,source=pnpm-store,target=/home/node/.pnpm-store",
-    "type=cache,source=next-cache,target=${containerWorkspaceFolder}/.next/cache"
+    "type=volume,source=pnpm-store,target=/home/node/.pnpm-store",
+    "type=volume,source=next-cache,target=${containerWorkspaceFolder}/.next/cache"
   ],
 
   "remoteUser": "vscode",


### PR DESCRIPTION
## Summary
- switch devcontainer cache mounts to use docker volumes so `docker run` works in Codespaces

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0552494888324beab9a0b4882f6dd