### PR TITLE
Add app helper functions for platform RLS hardening

### DIFF
--- a/packages/types/src/supabase.ts
+++ b/packages/types/src/supabase.ts
@@ -2357,6 +2357,36 @@ export type Database = {
       [_ in never]: never;
     };
   };
+  app: {
+    Tables: {
+      [_ in never]: never;
+    };
+    Views: {
+      [_ in never]: never;
+    };
+    Functions: {
+      current_user_id: {
+        Args: Record<string, never>;
+        Returns: string | null;
+      };
+      is_org_member: {
+        Args: {
+          target_org_id: string;
+        };
+        Returns: boolean;
+      };
+      is_platform_admin: {
+        Args: Record<string, never>;
+        Returns: boolean;
+      };
+    };
+    Enums: {
+      [_ in never]: never;
+    };
+    CompositeTypes: {
+      [_ in never]: never;
+    };
+  };
 };
 
 export type Tables<T extends keyof Database["public"]["Tables"]> = Database["public"]["Tables"][T]["Row"];


### PR DESCRIPTION
## Summary
- add `app` helper functions for current user identity, platform admin detection, and membership reuse
- update platform registry read policies to rely on the new helpers instead of null-tenant fallbacks
- fail the RLS check when policies use `tenant_org_id is null` and expose the helpers in generated Supabase types

## Testing
- node packages/db/check-rls.mjs

------
https://chatgpt.com/codex/tasks/task_e_68e065cb303483248e1dac8e60ac1121