### PR TITLE
Add platform rule source snapshots table

### DIFF
--- a/packages/freshness/src/watcher.ts
+++ b/packages/freshness/src/watcher.ts
@@ -188,7 +188,7 @@ async function loadPreviousPlatformSnapshot(
 ): Promise<PreviousSnapshot | undefined> {
   try {
     const { data, error } = await client
-      .from("rule_source_snapshots" as never)
+      .from("rule_source_snapshots")
       .select("id, content_hash, parsed_facts, fetched_at")
       .eq("rule_source_id", ruleSourceId)
       .order("fetched_at", { ascending: false })
@@ -237,7 +237,7 @@ async function savePlatformSnapshot(options: {
 
   try {
     const { data, error } = await client
-      .from("rule_source_snapshots" as never)
+      .from("rule_source_snapshots")
       .insert({
         rule_source_id: ruleSourceId,
         content_hash: fingerprint,

--- a/packages/types/src/supabase.ts
+++ b/packages/types/src/supabase.ts
@@ -2499,6 +2499,41 @@ export type Database = {
           }
         ];
       };
+      rule_source_snapshots: {
+        Row: {
+          id: string;
+          rule_source_id: string;
+          content_hash: string;
+          parsed_facts: Json;
+          fetched_at: string;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          rule_source_id: string;
+          content_hash: string;
+          parsed_facts?: Json;
+          fetched_at?: string;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          rule_source_id?: string;
+          content_hash?: string;
+          parsed_facts?: Json;
+          fetched_at?: string;
+          created_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "rule_source_snapshots_rule_source_id_fkey";
+            columns: ["rule_source_id"];
+            isOneToOne: false;
+            referencedRelation: "rule_sources";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       rule_sources: {
         Row: {
           id: string;


### PR DESCRIPTION
## Summary
- create the platform.rule_source_snapshots table with indexes and admin-only RLS, and sync schema.sql
- expose the new table through the generated Supabase typings so the watcher can query it without casts
- extend the freshness RLS regression test to cover persisting and protecting platform rule source snapshots

## Testing
- pnpm --filter @airnub/freshness test

------
https://chatgpt.com/codex/tasks/task_e_68e08413a80883249babcdf09fa892a7