### PR TITLE
feat(db): add jwt helper and admin claim regression test

### DIFF
--- a/packages/db/migrations/202503220001_app_jwt_helper.sql
+++ b/packages/db/migrations/202503220001_app_jwt_helper.sql
@@ -1,0 +1,82 @@
+-- Introduce app.jwt() helper and update platform admin checks
+set check_function_bodies = off;
+
+create schema if not exists app;
+
+create or replace function app.jwt()
+returns jsonb
+language sql
+stable
+as $$
+  select coalesce(
+    nullif(current_setting('request.jwt.claims', true), '')::jsonb,
+    '{}'::jsonb
+  );
+$$;
+
+create or replace function app.is_platform_admin()
+returns boolean
+language sql
+stable
+as $$
+  with claims as (
+    select app.jwt() as payload
+  )
+  select
+    coalesce(payload->>'role', '') = 'platform_admin'
+    or case jsonb_typeof(payload->'is_platform_admin')
+      when 'boolean' then (payload->'is_platform_admin')::boolean
+      when 'string' then lower(payload->>'is_platform_admin') in ('true','t','1','yes','y','on')
+      when 'number' then (payload->>'is_platform_admin')::numeric <> 0
+      else false
+    end
+  from claims;
+$$;
+
+create or replace function public.current_tenant_org_id()
+returns uuid
+language sql
+stable
+as $$
+  with claims as (
+    select app.jwt() as payload
+  )
+  select case
+    when payload ? 'tenant_org_id' then nullif(payload->>'tenant_org_id', '')::uuid
+    else null
+  end
+  from claims;
+$$;
+
+create or replace function public.jwt_has_org(target_org_id uuid)
+returns boolean
+language sql
+stable
+as $$
+  with claims as (
+    select app.jwt() as payload
+  )
+  select exists (
+    select 1
+    from claims,
+         jsonb_array_elements_text(coalesce(payload->'org_ids', '[]'::jsonb)) as org_id(value)
+    where value = target_org_id::text
+  );
+$$;
+
+create or replace function public.is_platform_service()
+returns boolean
+language sql
+stable
+as $$
+  with claims as (
+    select app.jwt() as payload
+  )
+  select auth.role() = 'service_role'
+    or exists (
+      select 1
+      from claims,
+           jsonb_array_elements_text(coalesce(payload->'role_paths', '[]'::jsonb)) as role_path(value)
+      where value like 'platform:service%'
+    );
+$$;

--- a/packages/db/tests/freshness_tables_rls.test.sql
+++ b/packages/db/tests/freshness_tables_rls.test.sql
@@ -16,6 +16,11 @@ declare
   v_adoption_id uuid;
   v_count integer;
 begin
+  perform set_config(
+    'request.jwt.claims',
+    jsonb_build_object('role', 'service_role')::text,
+    true
+  );
   perform set_config('request.jwt.claim.role', 'service_role', true);
 
   insert into organisations (id, tenant_org_id, name, slug)
@@ -127,6 +132,16 @@ begin
     raise exception 'Moderation queue insert did not append audit log entry';
   end if;
 
+  perform set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'role', 'authenticated',
+      'sub', user_one::text,
+      'tenant_org_id', tenant_one::text,
+      'org_ids', jsonb_build_array(tenant_one::text)
+    )::text,
+    true
+  );
   perform set_config('request.jwt.claim.role', 'authenticated', true);
   perform set_config('request.jwt.claim.sub', user_one::text, true);
   perform set_config('request.jwt.claim.tenant_org_id', tenant_one::text, true);
@@ -176,6 +191,16 @@ begin
     raise exception 'Adoption record insert did not append audit log entry';
   end if;
 
+  perform set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'role', 'authenticated',
+      'sub', user_two::text,
+      'tenant_org_id', tenant_two::text,
+      'org_ids', jsonb_build_array(tenant_two::text)
+    )::text,
+    true
+  );
   perform set_config('request.jwt.claim.sub', user_two::text, true);
   perform set_config('request.jwt.claim.tenant_org_id', tenant_two::text, true);
 

--- a/packages/db/tests/platform_admin_claim.test.sql
+++ b/packages/db/tests/platform_admin_claim.test.sql
@@ -1,0 +1,25 @@
+-- Regression: is_platform_admin claim grants admin access without role claim
+begin;
+
+do $$
+declare
+  v_source_id uuid;
+begin
+  perform set_config(
+    'request.jwt.claims',
+    jsonb_build_object('is_platform_admin', true)::text,
+    true
+  );
+  perform set_config('request.jwt.claim.is_platform_admin', 'true', true);
+
+  insert into platform.rule_sources (name, url, parser)
+  values ('Admin Claim Source', 'https://example.test/admin-claim', 'manual')
+  returning id into v_source_id;
+
+  if v_source_id is null then
+    raise exception 'Expected insert to return a platform rule source id';
+  end if;
+end;
+$$;
+
+rollback;

--- a/packages/db/tests/tenant_domain_takeover.test.sql
+++ b/packages/db/tests/tenant_domain_takeover.test.sql
@@ -7,6 +7,11 @@ declare
   tenant_two constant uuid := '00000000-0000-0000-0000-000000000002';
   domain_record tenant_domains%rowtype;
 begin
+  perform set_config(
+    'request.jwt.claims',
+    jsonb_build_object('role', 'service_role')::text,
+    true
+  );
   perform set_config('request.jwt.claim.role', 'service_role', true);
 
   insert into organisations (id, tenant_org_id, name, slug)


### PR DESCRIPTION
## Summary
- add an app.jwt() helper backed by request.jwt.claims and update platform admin helpers
- allow is_platform_admin claims to grant admin access and refresh SQL tests to seed full claim payloads
- add a regression SQL test that exercises platform admin access without a role claim

## Testing
- pnpm --filter @airnub/db verify:rls

------
https://chatgpt.com/codex/tasks/task_e_68e0841886a88324a15d039d69666b61