### PR TITLE
Expand RLS checks for null org IDs

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "migrate": "echo \"Run migrations via Supabase CLI\"",
     "seed": "echo \"Apply seeds.sql to your database\"",
-    "verify:rls": "node ./check-rls.mjs"
+    "verify:rls": "node ./check-rls.mjs",
+    "test": "node --test tests/check-rls.test.mjs"
   }
 }

--- a/packages/db/tests/check-rls.test.mjs
+++ b/packages/db/tests/check-rls.test.mjs
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { checkRlsSchema } from "../check-rls.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const schemaPath = resolve(__dirname, "../schema.sql");
+const baseSchema = await readFile(schemaPath, "utf8");
+
+test("rejects policies that allow tenant_org_id IS NULL", () => {
+  const schema = `${baseSchema}\ncreate policy "Test Null Tenant" on organisations\n  for select\n  using (tenant_org_id is null);\n`;
+
+  try {
+    checkRlsSchema(schema);
+    assert.fail("Expected tenant_org_id guard to throw");
+  } catch (error) {
+    assert.match(error.message, /tenant_org_id/i);
+    assert.match(error.message, /organisations\.Test Null Tenant/);
+  }
+});
+
+test("rejects policies that allow org_id IS NULL", () => {
+  const schema = `${baseSchema}\ncreate policy "Test Null Org" on organisations\n  for select\n  using (org_id is null);\n`;
+
+  try {
+    checkRlsSchema(schema);
+    assert.fail("Expected org_id guard to throw");
+  } catch (error) {
+    assert.match(error.message, /org_id/i);
+    assert.match(error.message, /organisations\.Test Null Org/);
+  }
+});


### PR DESCRIPTION
## Summary
- refactor the Supabase RLS checker to export helpers and reject policies that rely on `tenant_org_id` or `org_id` being NULL
- add node:test coverage exercising the new guard and wire the db package into the shared test task

## Testing
- pnpm --filter @airnub/db test
- node packages/db/check-rls.mjs

------
https://chatgpt.com/codex/tasks/task_e_68e0843dad408324ba79bc1512b65ddb