### PR TITLE
Add CI guard against direct platform Supabase writes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Check for disallowed platform mutations
+        run: scripts/check-platform-mutations.sh
+
       - name: Run ${{ matrix.display }}
         run: pnpm ${{ matrix.task }}
 

--- a/scripts/check-platform-mutations.sh
+++ b/scripts/check-platform-mutations.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "Error: ripgrep (rg) is required to run this check." >&2
+  exit 1
+fi
+
+if [ "$#" -gt 0 ]; then
+  TARGET_DIRS=("$@")
+else
+  TARGET_DIRS=("apps")
+fi
+
+PATTERN="from\\('platform\\.[^)]*\\)\\s*\\.(insert|update|upsert|delete)"
+
+set +e
+MATCHES=$(rg --pcre2 --glob 'src/**' -n "$PATTERN" "${TARGET_DIRS[@]}" 2>/dev/null)
+STATUS=$?
+set -e
+
+if [ $STATUS -eq 0 ]; then
+  echo "Disallowed Supabase mutations against the platform schema detected:" >&2
+  echo "$MATCHES" >&2
+  echo >&2
+  echo "Please route platform writes through the approved server-side services instead." >&2
+  exit 1
+elif [ $STATUS -eq 1 ]; then
+  exit 0
+else
+  echo "ripgrep exited with status $STATUS" >&2
+  exit $STATUS
+fi


### PR DESCRIPTION
## Summary
- add a reusable script that detects direct Supabase write calls against the platform schema
- run the platform write guard during the node-quality CI job

## Testing
- scripts/check-platform-mutations.sh

------
https://chatgpt.com/codex/tasks/task_e_68e0844419b883249a1b20b8c81c90f4