### PR TITLE
Add platform admin RLS regression coverage

### DIFF
--- a/packages/db/tests/freshness_tables_rls.test.sql
+++ b/packages/db/tests/freshness_tables_rls.test.sql
@@ -14,6 +14,9 @@ declare
   v_detection_id uuid;
   v_moderation_id uuid;
   v_adoption_id uuid;
+  v_admin_source_id uuid;
+  v_admin_adoption_id uuid;
+  v_text text;
   v_count integer;
 begin
   perform set_config('request.jwt.claim.role', 'service_role', true);
@@ -176,6 +179,83 @@ begin
     raise exception 'Adoption record insert did not append audit log entry';
   end if;
 
+  -- Platform administrators should bypass tenant-level RLS
+  perform set_config('request.jwt.claim.role', 'platform_admin', true);
+  perform set_config('request.jwt.claim.sub', user_one::text, true);
+
+  insert into source_registry (org_id, name, url, parser, jurisdiction, category)
+  values (tenant_two, 'Admin Source', 'https://example.test/admin-source', 'html', 'ie', 'platform-admin')
+  returning id into v_admin_source_id;
+
+  select count(*)
+  into v_count
+  from source_registry
+  where id = v_admin_source_id
+    and org_id = tenant_two;
+
+  if v_count <> 1 then
+    raise exception 'Platform admin should read and insert cross-tenant source registry rows';
+  end if;
+
+  update source_registry
+  set parser = 'xml'
+  where id = v_admin_source_id;
+
+  select parser into v_text
+  from source_registry
+  where id = v_admin_source_id;
+
+  if v_text <> 'xml' then
+    raise exception 'Platform admin update on tenant sources should succeed';
+  end if;
+
+  perform 1
+  from platform.rule_sources
+  where id = v_platform_source_id;
+
+  update platform.rule_sources
+  set parser = 'json'
+  where id = v_platform_source_id;
+
+  select parser into v_text
+  from platform.rule_sources
+  where id = v_platform_source_id;
+
+  if v_text <> 'json' then
+    raise exception 'Platform admin should be able to update platform rule sources';
+  end if;
+
+  perform 1
+  from platform.rule_pack_detections
+  where id = v_detection_id;
+
+  update platform.rule_pack_detections
+  set severity = 'major'
+  where id = v_detection_id;
+
+  select severity into v_text
+  from platform.rule_pack_detections
+  where id = v_detection_id;
+
+  if v_text <> 'major' then
+    raise exception 'Platform admin should be able to update platform rule pack detections';
+  end if;
+
+  insert into adoption_records (org_id, scope, ref_id, from_version, to_version, mode, actor_id)
+  values (tenant_two, 'rule', 'admin_rule', '1.0.0', '1.2.0', 'manual', user_one)
+  returning id into v_admin_adoption_id;
+
+  select count(*)
+  into v_count
+  from adoption_records
+  where id = v_admin_adoption_id
+    and org_id = tenant_two;
+
+  if v_count <> 1 then
+    raise exception 'Platform admin should be able to manage adoption records for any tenant';
+  end if;
+
+  perform set_config('request.jwt.claim.role', 'authenticated', true);
   perform set_config('request.jwt.claim.sub', user_two::text, true);
   perform set_config('request.jwt.claim.tenant_org_id', tenant_two::text, true);
 


### PR DESCRIPTION
## Summary
- extend the RLS regression test to simulate a platform admin JWT
- assert platform admins can read and write tenant resources and platform rule pack tables to guard against regressions

## Testing
- not run (SQL regression test only)


------
https://chatgpt.com/codex/tasks/task_e_68e08449f41c8324b6a1ecd50d7b8b56