### PR TITLE
Add org scoping to workflow definitions

### DIFF
--- a/apps/admin/src/app/[locale]/freshness/__tests__/actions.test.ts
+++ b/apps/admin/src/app/[locale]/freshness/__tests__/actions.test.ts
@@ -54,6 +54,7 @@ function seedSupabase() {
     workflow_defs: [
       {
         id: "workflow-def-1",
+        org_id: TENANT_ID,
         key: "setup-nonprofit-ie",
         version: "1.2.3",
         title: "Workflow",

--- a/apps/portal/src/server/__tests__/workflow-runs.test.ts
+++ b/apps/portal/src/server/__tests__/workflow-runs.test.ts
@@ -40,61 +40,62 @@ test("createWorkflowRun materialises lockfile and stores snapshot", async () => 
       workflow_defs: [
         {
           id: WORKFLOW_DEF_ID,
+          org_id: TENANT_ID,
           key: baseGraph.id,
           version: baseGraph.version,
-        title: "Demo",
-        dsl_json: baseGraph
-      }
-    ],
-    workflow_def_versions: [
-      {
-        id: "definition-version-1",
-        tenant_org_id: TENANT_ID,
-        workflow_def_id: WORKFLOW_DEF_ID,
-        version: baseGraph.version,
-        checksum: "wf-checksum",
-        graph_jsonb: baseGraph,
-        rule_ranges: { "rule.deadline": { version: "2.0.0" } },
-        template_ranges: { constitution: { version: "3.1.0" } }
-      }
-    ],
-    workflow_pack_versions: [
-      {
-        id: "overlay-version-1",
-        tenant_org_id: TENANT_ID,
-        pack_id: "tenant-pack",
-        version: "1.2.0",
-        checksum: "overlay-checksum",
-        overlay_jsonb: overlayOperations
-      }
-    ],
-    rule_versions: [
-      {
-        id: "rule-version-1",
-        tenant_org_id: TENANT_ID,
-        rule_id: "rule.deadline",
-        version: "2.0.0",
-        checksum: "rule-checksum",
-        sources: [
-          {
-            source_key: "cro_open_services",
-            snapshot_id: "snapshot-1",
-            fingerprint: "fingerprint-1"
-          }
-        ]
-      }
-    ],
-    template_versions: [
-      {
-        id: "template-version-1",
-        tenant_org_id: TENANT_ID,
-        template_id: "constitution",
-        version: "3.1.0",
-        checksum: "template-checksum",
-        storage_ref: "s3://templates/constitution"
-      }
-    ]
-  });
+          title: "Demo",
+          dsl_json: baseGraph
+        }
+      ],
+      workflow_def_versions: [
+        {
+          id: "definition-version-1",
+          org_id: TENANT_ID,
+          workflow_def_id: WORKFLOW_DEF_ID,
+          version: baseGraph.version,
+          checksum: "wf-checksum",
+          graph_jsonb: baseGraph,
+          rule_ranges: { "rule.deadline": { version: "2.0.0" } },
+          template_ranges: { constitution: { version: "3.1.0" } }
+        }
+      ],
+      workflow_pack_versions: [
+        {
+          id: "overlay-version-1",
+          org_id: TENANT_ID,
+          pack_id: "tenant-pack",
+          version: "1.2.0",
+          checksum: "overlay-checksum",
+          overlay_jsonb: overlayOperations
+        }
+      ],
+      rule_versions: [
+        {
+          id: "rule-version-1",
+          org_id: TENANT_ID,
+          rule_id: "rule.deadline",
+          version: "2.0.0",
+          checksum: "rule-checksum",
+          sources: [
+            {
+              source_key: "cro_open_services",
+              snapshot_id: "snapshot-1",
+              fingerprint: "fingerprint-1"
+            }
+          ]
+        }
+      ],
+      template_versions: [
+        {
+          id: "template-version-1",
+          org_id: TENANT_ID,
+          template_id: "constitution",
+          version: "3.1.0",
+          checksum: "template-checksum",
+          storage_ref: "s3://templates/constitution"
+        }
+      ]
+    });
 
     const overlays: OverlayReference[] = [{ id: "tenant-pack", version: "1.2.0" }];
     const result = await createWorkflowRun(client, {
@@ -138,6 +139,7 @@ test("createWorkflowRun resolves range selectors to latest satisfying versions",
       workflow_defs: [
         {
           id: WORKFLOW_DEF_ID,
+          org_id: TENANT_ID,
           key: baseGraph.id,
           version: baseGraph.version,
           title: "Demo",
@@ -147,7 +149,7 @@ test("createWorkflowRun resolves range selectors to latest satisfying versions",
       workflow_def_versions: [
         {
           id: "definition-version-range",
-          tenant_org_id: TENANT_ID,
+          org_id: TENANT_ID,
           workflow_def_id: WORKFLOW_DEF_ID,
           version: baseGraph.version,
           checksum: "wf-range-checksum",
@@ -159,7 +161,7 @@ test("createWorkflowRun resolves range selectors to latest satisfying versions",
       workflow_pack_versions: [
         {
           id: "overlay-version-range",
-          tenant_org_id: TENANT_ID,
+          org_id: TENANT_ID,
           pack_id: "tenant-pack",
           version: "1.3.0",
           checksum: "overlay-range-checksum",
@@ -169,7 +171,7 @@ test("createWorkflowRun resolves range selectors to latest satisfying versions",
       rule_versions: [
         {
           id: "rule-version-1",
-          tenant_org_id: TENANT_ID,
+          org_id: TENANT_ID,
           rule_id: "rule.deadline",
           version: "1.5.0",
           checksum: "rule-checksum-1",
@@ -177,7 +179,7 @@ test("createWorkflowRun resolves range selectors to latest satisfying versions",
         },
         {
           id: "rule-version-2",
-          tenant_org_id: TENANT_ID,
+          org_id: TENANT_ID,
           rule_id: "rule.deadline",
           version: "2.0.0",
           checksum: "rule-checksum-2",
@@ -185,7 +187,7 @@ test("createWorkflowRun resolves range selectors to latest satisfying versions",
         },
         {
           id: "rule-version-3",
-          tenant_org_id: TENANT_ID,
+          org_id: TENANT_ID,
           rule_id: "rule.deadline",
           version: "2.5.0",
           checksum: "rule-checksum-3",
@@ -195,7 +197,7 @@ test("createWorkflowRun resolves range selectors to latest satisfying versions",
       template_versions: [
         {
           id: "template-version-1",
-          tenant_org_id: TENANT_ID,
+          org_id: TENANT_ID,
           template_id: "constitution",
           version: "2.9.0",
           checksum: "template-checksum-1",
@@ -203,7 +205,7 @@ test("createWorkflowRun resolves range selectors to latest satisfying versions",
         },
         {
           id: "template-version-2",
-          tenant_org_id: TENANT_ID,
+          org_id: TENANT_ID,
           template_id: "constitution",
           version: "3.0.0",
           checksum: "template-checksum-2",
@@ -211,7 +213,7 @@ test("createWorkflowRun resolves range selectors to latest satisfying versions",
         },
         {
           id: "template-version-3",
-          tenant_org_id: TENANT_ID,
+          org_id: TENANT_ID,
           template_id: "constitution",
           version: "3.2.0",
           checksum: "template-checksum-3",

--- a/apps/portal/src/server/workflow-runs.ts
+++ b/apps/portal/src/server/workflow-runs.ts
@@ -103,7 +103,7 @@ function createSupabaseMaterializeContext(
         .select("id, workflow_def_id, version, checksum, graph_jsonb, rule_ranges, template_ranges")
         .eq("workflow_def_id", definition.id)
         .eq("version", version)
-        .eq("tenant_org_id", tenantOrgId)
+        .eq("org_id", tenantOrgId)
         .maybeSingle();
 
       if (versionError) {
@@ -128,7 +128,7 @@ function createSupabaseMaterializeContext(
       const { data: row, error } = await client
         .from("workflow_pack_versions")
         .select("id, pack_id, version, checksum, overlay_jsonb")
-        .eq("tenant_org_id", tenantOrgId)
+        .eq("org_id", tenantOrgId)
         .eq("pack_id", ref.id)
         .eq("version", ref.version)
         .maybeSingle();
@@ -153,7 +153,7 @@ function createSupabaseMaterializeContext(
       const { data: row, error } = await client
         .from("rule_versions")
         .select("id, rule_id, version, checksum, sources")
-        .eq("tenant_org_id", tenantOrgId)
+        .eq("org_id", tenantOrgId)
         .eq("rule_id", ruleId)
         .eq("version", version)
         .maybeSingle();
@@ -177,7 +177,7 @@ function createSupabaseMaterializeContext(
       const { data: row, error } = await client
         .from("template_versions")
         .select("id, template_id, version, checksum")
-        .eq("tenant_org_id", tenantOrgId)
+        .eq("org_id", tenantOrgId)
         .eq("template_id", templateId)
         .eq("version", version)
         .maybeSingle();
@@ -238,7 +238,7 @@ async function resolveSelectorVersion(
         const { data, error } = await client
           .from("rule_versions")
           .select("version")
-          .eq("tenant_org_id", tenantOrgId)
+          .eq("org_id", tenantOrgId)
           .eq("rule_id", id);
         if (error) {
           throw new Error(`Unable to load rule versions for ${id}: ${error.message}`);
@@ -256,7 +256,7 @@ async function resolveSelectorVersion(
       const { data, error } = await client
         .from("template_versions")
         .select("version")
-        .eq("tenant_org_id", tenantOrgId)
+        .eq("org_id", tenantOrgId)
         .eq("template_id", id);
       if (error) {
         throw new Error(`Unable to load template versions for ${id}: ${error.message}`);

--- a/packages/db/check-rls.mjs
+++ b/packages/db/check-rls.mjs
@@ -40,8 +40,8 @@ const requiredPolicies = {
   memberships: ["Users can read their memberships", "Service role manages memberships"],
   engagements: ["Members view engagements", "Service role manages engagements"],
   workflow_defs: [
-    "Authenticated can view workflow definitions",
-    "Service role manages workflow definitions"
+    "Org members read workflow definitions",
+    "Org members manage workflow definitions"
   ],
   workflow_runs: ["Members access workflow runs", "Service role manages workflow runs"],
   steps: ["Members read steps", "Service role manages steps"],

--- a/packages/db/migrations/202503310001_workflow_defs_org.sql
+++ b/packages/db/migrations/202503310001_workflow_defs_org.sql
@@ -1,0 +1,107 @@
+begin;
+
+alter table workflow_defs add column if not exists org_id uuid;
+
+update workflow_defs wd
+set org_id = sub.org_id
+from (
+  select workflow_def_id, org_id
+  from (
+    select workflow_def_id, org_id,
+           row_number() over (partition by workflow_def_id order by created_at desc nulls last) as rn
+    from workflow_def_versions
+  ) ranked
+  where rn = 1
+) sub
+where wd.id = sub.workflow_def_id
+  and wd.org_id is distinct from sub.org_id;
+
+update workflow_defs wd
+set org_id = sub.org_id
+from (
+  select workflow_def_id, org_id
+  from (
+    select workflow_def_id, org_id,
+           row_number() over (partition by workflow_def_id order by updated_at desc nulls last, created_at desc nulls last) as rn
+    from tenant_workflow_overlays
+  ) ranked
+  where rn = 1
+) sub
+where wd.id = sub.workflow_def_id
+  and wd.org_id is null;
+
+update workflow_defs wd
+set org_id = sub.tenant_org_id
+from (
+  select workflow_def_id, tenant_org_id,
+         row_number() over (partition by workflow_def_id order by created_at desc nulls last) as rn
+  from workflow_runs
+  where workflow_def_id is not null
+) sub
+where wd.id = sub.workflow_def_id
+  and sub.rn = 1
+  and wd.org_id is null;
+
+do $$
+begin
+  if exists (select 1 from workflow_defs where org_id is null) then
+    raise exception 'workflow_defs org_id backfill failed';
+  end if;
+end;
+$$;
+
+alter table workflow_defs
+  alter column org_id set not null;
+
+alter table workflow_defs
+  add constraint workflow_defs_org_id_fkey
+    foreign key (org_id) references organisations(id);
+
+create unique index if not exists workflow_defs_org_id_id_key on workflow_defs(org_id, id);
+create index if not exists workflow_defs_org_key_idx on workflow_defs(org_id, key);
+
+update workflow_def_versions v
+set org_id = wd.org_id
+from workflow_defs wd
+where v.workflow_def_id = wd.id
+  and v.org_id is distinct from wd.org_id;
+
+update tenant_workflow_overlays two
+set org_id = wd.org_id
+from workflow_defs wd
+where two.workflow_def_id = wd.id
+  and two.org_id is distinct from wd.org_id;
+
+update workflow_runs wr
+set tenant_org_id = wd.org_id
+from workflow_defs wd
+where wr.workflow_def_id = wd.id
+  and wd.org_id is distinct from wr.tenant_org_id;
+
+alter table workflow_def_versions
+  drop constraint if exists workflow_def_versions_workflow_def_id_fkey;
+
+alter table workflow_def_versions
+  add constraint workflow_def_versions_workflow_def_fk
+    foreign key (org_id, workflow_def_id)
+    references workflow_defs(org_id, id)
+    on delete cascade;
+
+alter table tenant_workflow_overlays
+  drop constraint if exists tenant_workflow_overlays_workflow_def_id_fkey;
+
+alter table tenant_workflow_overlays
+  add constraint tenant_workflow_overlays_workflow_def_fk
+    foreign key (org_id, workflow_def_id)
+    references workflow_defs(org_id, id)
+    on delete cascade;
+
+alter table workflow_runs
+  drop constraint if exists workflow_runs_workflow_def_id_fkey;
+
+alter table workflow_runs
+  add constraint workflow_runs_workflow_def_fk
+    foreign key (tenant_org_id, workflow_def_id)
+    references workflow_defs(org_id, id);
+
+commit;

--- a/packages/db/tests/workflow_defs_rls.test.sql
+++ b/packages/db/tests/workflow_defs_rls.test.sql
@@ -1,0 +1,99 @@
+-- Workflow definitions enforce tenant scoping and admin overrides
+begin;
+
+do $$
+declare
+  tenant_one constant uuid := '00000000-0000-0000-0000-000000000101';
+  tenant_two constant uuid := '00000000-0000-0000-0000-000000000202';
+  user_one constant uuid := '00000000-0000-0000-0000-000000000901';
+  def_one constant uuid := '11111111-1111-1111-1111-111111110001';
+  def_two constant uuid := '22222222-2222-2222-2222-222222220002';
+  inserted_id uuid;
+  visible_count integer;
+begin
+  perform set_config(
+    'request.jwt.claims',
+    jsonb_build_object('role', 'service_role')::text,
+    true
+  );
+  perform set_config('request.jwt.claim.role', 'service_role', true);
+
+  insert into organisations (id, tenant_org_id, name, slug)
+  values
+    (tenant_one, tenant_one, 'Tenant One', 'tenant-one'),
+    (tenant_two, tenant_two, 'Tenant Two', 'tenant-two')
+  on conflict (id) do nothing;
+
+  insert into users (id, email)
+  values
+    (user_one, 'workflow-user@example.com')
+  on conflict (id) do nothing;
+
+  insert into memberships (user_id, org_id, role)
+  values (user_one, tenant_one, 'admin')
+  on conflict do nothing;
+
+  insert into workflow_defs (id, org_id, key, version, title, dsl_json)
+  values
+    (def_one, tenant_one, 'tenant.workflow.one', '1.0.0', 'Tenant Workflow One', '{}'::jsonb),
+    (def_two, tenant_two, 'tenant.workflow.two', '1.0.0', 'Tenant Workflow Two', '{}'::jsonb)
+  on conflict (id) do nothing;
+
+  insert into workflow_def_versions (org_id, workflow_def_id, version, graph_jsonb, checksum)
+  values
+    (tenant_one, def_one, '1.0.0', '{}'::jsonb, 'checksum-one'),
+    (tenant_two, def_two, '1.0.0', '{}'::jsonb, 'checksum-two')
+  on conflict (id) do nothing;
+
+  perform set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'role', 'authenticated',
+      'sub', user_one::text,
+      'tenant_org_id', tenant_one::text,
+      'org_ids', jsonb_build_array(tenant_one::text)
+    )::text,
+    true
+  );
+  perform set_config('request.jwt.claim.role', 'authenticated', true);
+  perform set_config('request.jwt.claim.sub', user_one::text, true);
+  perform set_config('request.jwt.claim.tenant_org_id', tenant_one::text, true);
+
+  select count(*) into visible_count from workflow_defs;
+  if visible_count <> 1 then
+    raise exception 'Tenant members should only see workflow definitions in their org';
+  end if;
+
+  begin
+    insert into workflow_defs (org_id, key, version, title, dsl_json)
+    values (tenant_two, 'cross.tenant', '1.0.0', 'Cross Tenant', '{}'::jsonb);
+    raise exception 'Cross-tenant workflow definition insert should be rejected';
+  exception
+    when sqlstate '42501' then
+      null;
+  end;
+
+  insert into workflow_defs (org_id, key, version, title, dsl_json)
+  values (tenant_one, 'tenant.workflow.one', '1.1.0', 'Tenant Workflow One v2', '{}'::jsonb)
+  returning id into inserted_id;
+
+  delete from workflow_defs where id = inserted_id;
+
+  perform set_config(
+    'request.jwt.claims',
+    jsonb_build_object('is_platform_admin', true)::text,
+    true
+  );
+  perform set_config('request.jwt.claim.is_platform_admin', 'true', true);
+
+  select count(*) into visible_count from workflow_defs;
+  if visible_count <> 2 then
+    raise exception 'Platform admins should see all workflow definitions';
+  end if;
+
+  insert into workflow_defs (org_id, key, version, title, dsl_json)
+  values (tenant_two, 'admin.workflow', '9.9.9', 'Admin Workflow', '{}'::jsonb);
+end;
+$$;
+
+rollback;

--- a/packages/types/src/supabase.ts
+++ b/packages/types/src/supabase.ts
@@ -499,11 +499,11 @@ export type Database = {
             referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "workflow_def_versions_workflow_def_id_fkey";
-            columns: ["workflow_def_id"];
+            foreignKeyName: "workflow_def_versions_workflow_def_fk";
+            columns: ["org_id", "workflow_def_id"];
             isOneToOne: false;
             referencedRelation: "workflow_defs";
-            referencedColumns: ["id"];
+            referencedColumns: ["org_id", "id"];
           }
         ];
       };
@@ -889,6 +889,7 @@ export type Database = {
       workflow_defs: {
         Row: {
           id: string;
+          org_id: string;
           key: string;
           version: string;
           title: string;
@@ -897,6 +898,7 @@ export type Database = {
         };
         Insert: {
           id?: string;
+          org_id: string;
           key: string;
           version: string;
           title: string;
@@ -905,13 +907,22 @@ export type Database = {
         };
         Update: {
           id?: string;
+          org_id?: string;
           key?: string;
           version?: string;
           title?: string;
           dsl_json?: Json;
           created_at?: string | null;
         };
-        Relationships: [];
+        Relationships: [
+          {
+            foreignKeyName: "workflow_defs_org_id_fkey";
+            columns: ["org_id"];
+            isOneToOne: false;
+            referencedRelation: "organisations";
+            referencedColumns: ["id"];
+          }
+        ];
       };
       workflow_runs: {
         Row: {
@@ -983,11 +994,11 @@ export type Database = {
             referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "workflow_runs_workflow_def_id_fkey";
-            columns: ["workflow_def_id"];
+            foreignKeyName: "workflow_runs_workflow_def_fk";
+            columns: ["tenant_org_id", "workflow_def_id"];
             isOneToOne: false;
             referencedRelation: "workflow_defs";
-            referencedColumns: ["id"];
+            referencedColumns: ["org_id", "id"];
           }
         ];
       };
@@ -1426,11 +1437,11 @@ export type Database = {
             referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "tenant_workflow_overlays_workflow_def_id_fkey";
-            columns: ["workflow_def_id"];
+            foreignKeyName: "tenant_workflow_overlays_workflow_def_fk";
+            columns: ["org_id", "workflow_def_id"];
             isOneToOne: false;
             referencedRelation: "workflow_defs";
-            referencedColumns: ["id"];
+            referencedColumns: ["org_id", "id"];
           }
         ];
       };


### PR DESCRIPTION
## Summary
- add a forward-only migration that assigns organisations to workflow definitions and enforces composite foreign keys
- update the schema snapshot, RLS policies, and Supabase types so workflow definition access is org-scoped
- adjust application/tests to provide org identifiers and add a regression test covering workflow definition RLS

## Testing
- pnpm --filter db verify:rls
- pnpm --filter portal test *(fails: missing semver dependency in test runner environment)*
- pnpm --filter admin test *(fails: vitest binary unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e08886ac308324a0fe2693ba76d46d