### PR TITLE
Enforce org_id integrity for tenant overlays and secret bindings

### DIFF
--- a/packages/db/migrations/202504010001_enforce_overlay_org_scope.sql
+++ b/packages/db/migrations/202504010001_enforce_overlay_org_scope.sql
@@ -1,0 +1,109 @@
+begin;
+
+with latest_bindings as (
+  select distinct on (target_id) target_id, tenant_org_id
+  from audit_log
+  where target_kind = 'tenant_secret_binding'
+    and tenant_org_id is not null
+  order by target_id, created_at desc
+)
+update tenant_secret_bindings tsb
+set org_id = latest_bindings.tenant_org_id
+from latest_bindings
+where tsb.id = latest_bindings.target_id
+  and tsb.org_id is null;
+
+with overlay_orgs as (
+  select distinct on (target_id) target_id, tenant_org_id
+  from audit_log
+  where target_kind = 'tenant_workflow_overlay'
+    and tenant_org_id is not null
+  order by target_id, created_at desc
+),
+resolved_overlays as (
+  select two.id,
+         coalesce(overlay_orgs.tenant_org_id,
+           (
+             select wr.tenant_org_id
+             from workflow_overlay_snapshots s
+             join workflow_runs wr on wr.id = s.run_id
+             where s.tenant_overlay_id = two.id
+               and wr.tenant_org_id is not null
+             order by s.created_at desc
+             limit 1
+           )
+         ) as tenant_org_id
+  from tenant_workflow_overlays two
+  left join overlay_orgs on overlay_orgs.target_id = two.id
+  where two.org_id is null
+)
+update tenant_workflow_overlays two
+set org_id = resolved_overlays.tenant_org_id
+from resolved_overlays
+where two.id = resolved_overlays.id
+  and two.org_id is null
+  and resolved_overlays.tenant_org_id is not null;
+
+alter table tenant_secret_bindings
+  alter column org_id set not null;
+
+alter table tenant_workflow_overlays
+  alter column org_id set not null;
+
+create index if not exists tenant_secret_bindings_org_alias_idx
+  on tenant_secret_bindings(org_id, alias);
+
+create index if not exists tenant_workflow_overlays_org_workflow_idx
+  on tenant_workflow_overlays(org_id, workflow_def_id);
+
+alter policy "Tenant members manage secret bindings" on tenant_secret_bindings
+  for select using (
+    auth.role() = 'service_role'
+    or app.is_org_member(org_id)
+  );
+
+alter policy "Tenant members manage overlays" on tenant_workflow_overlays
+  for select using (
+    auth.role() = 'service_role'
+    or app.is_org_member(org_id)
+  )
+  with check (
+    auth.role() = 'service_role'
+    or app.is_org_member(org_id)
+  );
+
+alter policy "Members read overlay snapshots" on workflow_overlay_snapshots
+  for select using (
+    auth.role() = 'service_role'
+    or (run_id is not null and public.can_access_run(run_id))
+    or exists (
+      select 1
+      from tenant_workflow_overlays two
+      where two.id = tenant_overlay_id
+        and app.is_org_member(two.org_id)
+    )
+  );
+
+alter policy "Members read overlay layers" on workflow_overlay_layers
+  for select using (
+    auth.role() = 'service_role'
+    or exists (
+      select 1
+      from workflow_overlay_snapshots s
+      where s.id = snapshot_id
+        and (
+          (s.run_id is not null and public.can_access_run(s.run_id))
+          or (
+            s.tenant_overlay_id is not null
+            and exists (
+              select 1
+              from tenant_workflow_overlays two
+              where two.id = s.tenant_overlay_id
+                and app.is_org_member(two.org_id)
+            )
+          )
+        )
+    )
+  );
+
+commit;

--- a/packages/db/tests/tenant_extension_scope.test.sql
+++ b/packages/db/tests/tenant_extension_scope.test.sql
@@ -1,0 +1,185 @@
+-- Tenant-scoped secrets and overlays enforce org_id isolation with admin override
+begin;
+
+do $$
+declare
+  tenant_one constant uuid := '00000000-0000-0000-0000-000000000111';
+  tenant_two constant uuid := '00000000-0000-0000-0000-000000000222';
+  user_one constant uuid := '00000000-0000-0000-0000-000000000911';
+  user_two constant uuid := '00000000-0000-0000-0000-000000000922';
+  workflow_def_one uuid;
+  workflow_def_two uuid;
+  overlay_two uuid;
+  snapshot_two uuid;
+  v_count integer;
+  binding_id uuid;
+  overlay_id uuid;
+begin
+  -- bootstrap data with elevated privileges
+  perform set_config('request.jwt.claim.role', 'service_role', true);
+  perform set_config(
+    'request.jwt.claims',
+    jsonb_build_object('role', 'service_role')::text,
+    true
+  );
+
+  insert into organisations (id, tenant_org_id, name, slug)
+  values
+    (tenant_one, tenant_one, 'Tenant One', 'tenant-one'),
+    (tenant_two, tenant_two, 'Tenant Two', 'tenant-two')
+  on conflict (id) do nothing;
+
+  insert into users (id, email)
+  values
+    (user_one, 'member1@example.com'),
+    (user_two, 'member2@example.com')
+  on conflict (id) do nothing;
+
+  insert into memberships (user_id, org_id, role)
+  values
+    (user_one, tenant_one, 'admin'),
+    (user_two, tenant_two, 'admin')
+  on conflict do nothing;
+
+  insert into workflow_defs (id, key, version, title, dsl_json)
+  values
+    (gen_random_uuid(), 'core', '1.0.0', 'Core Workflow', '{}'::jsonb)
+  returning id into workflow_def_one;
+
+  insert into workflow_defs (id, key, version, title, dsl_json)
+  values
+    (gen_random_uuid(), 'core-two', '1.0.0', 'Core Workflow Two', '{}'::jsonb)
+  returning id into workflow_def_two;
+
+  insert into tenant_workflow_overlays (org_id, workflow_def_id, title, patch)
+  values (tenant_two, workflow_def_two, 'Tenant Two Overlay', '[]'::jsonb)
+  returning id into overlay_two;
+
+  insert into tenant_secret_bindings (org_id, alias, provider, external_id)
+  values (tenant_two, 'tenant-two-alias', 'env', 'TENANT_TWO_SECRET')
+  on conflict do nothing;
+
+  insert into workflow_overlay_snapshots (tenant_overlay_id, applied_overlays, merged_workflow)
+  values (overlay_two, '[]'::jsonb, jsonb_build_object('steps', jsonb_build_array()))
+  returning id into snapshot_two;
+
+  insert into workflow_overlay_layers (snapshot_id, source, patch)
+  values (snapshot_two, 'tenant-two', '[]'::jsonb);
+
+  perform set_config('request.jwt.claim.role', 'authenticated', true);
+  perform set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'role', 'authenticated',
+      'sub', user_one::text,
+      'tenant_org_id', tenant_one::text,
+      'org_ids', jsonb_build_array(tenant_one::text)
+    )::text,
+    true
+  );
+  perform set_config('request.jwt.claim.sub', user_one::text, true);
+  perform set_config('request.jwt.claim.tenant_org_id', tenant_one::text, true);
+
+  -- Tenant member can create resources for their org
+  insert into tenant_secret_bindings (org_id, alias, provider, external_id)
+  values (tenant_one, 'tenant-one-alias', 'env', 'TENANT_ONE_SECRET')
+  returning id into binding_id;
+
+  insert into tenant_workflow_overlays (org_id, workflow_def_id, title, patch)
+  values (tenant_one, workflow_def_one, 'Tenant One Overlay', '[]'::jsonb)
+  returning id into overlay_id;
+
+  -- Cross-tenant insert should fail
+  begin
+    insert into tenant_secret_bindings (org_id, alias, provider, external_id)
+    values (tenant_two, 'forbidden-alias', 'env', 'DENIED');
+    raise exception 'Cross-tenant secret binding insert should fail';
+  exception
+    when sqlstate '42501' then
+      null;
+  end;
+
+  begin
+    insert into tenant_workflow_overlays (org_id, workflow_def_id, title, patch)
+    values (tenant_two, workflow_def_two, 'Forbidden Overlay', '[]'::jsonb);
+    raise exception 'Cross-tenant overlay insert should fail';
+  exception
+    when sqlstate '42501' then
+      null;
+  end;
+
+  -- Cross-tenant reads should return nothing
+  select count(*) into v_count
+  from tenant_secret_bindings
+  where org_id = tenant_two;
+
+  if v_count <> 0 then
+    raise exception 'Tenant member should not see other tenant secret bindings';
+  end if;
+
+  select count(*) into v_count
+  from tenant_workflow_overlays
+  where org_id = tenant_two;
+
+  if v_count <> 0 then
+    raise exception 'Tenant member should not see other tenant overlays';
+  end if;
+
+  select count(*) into v_count
+  from workflow_overlay_snapshots s
+  where s.tenant_overlay_id = overlay_two;
+
+  if v_count <> 0 then
+    raise exception 'Tenant member should not see other tenant overlay snapshots';
+  end if;
+
+  select count(*) into v_count
+  from workflow_overlay_layers l
+  where l.snapshot_id = snapshot_two;
+
+  if v_count <> 0 then
+    raise exception 'Tenant member should not see other tenant overlay layers';
+  end if;
+
+  -- Platform admin claim bypasses tenant scoping
+  perform set_config('request.jwt.claim.role', 'platform_admin', true);
+  perform set_config('request.jwt.claim.is_platform_admin', 'true', true);
+  perform set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'role', 'platform_admin',
+      'sub', user_one::text,
+      'is_platform_admin', true
+    )::text,
+    true
+  );
+
+  insert into tenant_secret_bindings (org_id, alias, provider, external_id)
+  values (tenant_two, 'admin-alias', 'env', 'PLATFORM_OVERRIDE')
+  on conflict do nothing;
+
+  insert into tenant_workflow_overlays (org_id, workflow_def_id, title, patch)
+  values (tenant_two, workflow_def_two, 'Admin Overlay', '[]'::jsonb)
+  on conflict do nothing;
+
+  select count(*) into v_count
+  from tenant_secret_bindings
+  where org_id = tenant_two
+    and alias = 'admin-alias';
+
+  if v_count <> 1 then
+    raise exception 'Platform admin should insert cross-tenant secret binding';
+  end if;
+
+  select count(*) into v_count
+  from tenant_workflow_overlays
+  where org_id = tenant_two
+    and title = 'Admin Overlay';
+
+  if v_count <> 1 then
+    raise exception 'Platform admin should insert cross-tenant overlay';
+  end if;
+end;
+$$;
+
+rollback;

--- a/packages/types/src/supabase.ts
+++ b/packages/types/src/supabase.ts
@@ -1437,7 +1437,7 @@ export type Database = {
       workflow_overlay_snapshots: {
         Row: {
           id: string;
-          run_id: string;
+          run_id: string | null;
           tenant_overlay_id: string | null;
           applied_overlays: Json;
           merged_workflow: Json;
@@ -1445,7 +1445,7 @@ export type Database = {
         };
         Insert: {
           id?: string;
-          run_id: string;
+          run_id?: string | null;
           tenant_overlay_id?: string | null;
           applied_overlays?: Json;
           merged_workflow: Json;
@@ -1453,7 +1453,7 @@ export type Database = {
         };
         Update: {
           id?: string;
-          run_id?: string;
+          run_id?: string | null;
           tenant_overlay_id?: string | null;
           applied_overlays?: Json;
           merged_workflow?: Json;


### PR DESCRIPTION
## Summary
- backfill tenant secret bindings and overlays with missing org_id values, enforce NOT NULL, and add supporting indexes and tightened RLS policies
- expand workflow overlay snapshot and layer policies to honor tenant membership via app.is_org_member and align generated Supabase types
- add tenant regression SQL coverage to ensure members cannot cross-tenant read/write while platform admins retain override capabilities

## Testing
- pnpm --filter @airnub/db test

------
https://chatgpt.com/codex/tasks/task_e_68e088c9ac848324bb9e882dc4b7aa22