### PR TITLE
Backfill tenant step installs org IDs before enforcing not-null

### DIFF
--- a/packages/db/migrations/202510050001_tenant_step_install_org_backfill.sql
+++ b/packages/db/migrations/202510050001_tenant_step_install_org_backfill.sql
@@ -1,0 +1,34 @@
+begin;
+
+-- Backfill and enforce tenant scope on tenant_step_type_installs.org_id
+perform pg_advisory_xact_lock(hashtext('tenant_step_type_installs.org_id.backfill'));
+
+with install_audit as (
+  select distinct on (target_id) target_id, tenant_org_id
+  from audit_log
+  where target_id is not null
+    and tenant_org_id is not null
+    and (
+      target_kind in ('tenant_step_type_install', 'tenant_step_type_installs')
+      or entity = 'tenant_step_type_installs'
+    )
+  order by target_id, created_at desc
+)
+update tenant_step_type_installs tsi
+set org_id = install_audit.tenant_org_id
+from install_audit
+where tsi.id = install_audit.target_id
+  and tsi.org_id is null;
+
+do $$
+begin
+  if exists (select 1 from tenant_step_type_installs where org_id is null) then
+    raise exception 'tenant_step_type_installs has NULL org_id rows after backfill';
+  end if;
+end;
+$$;
+
+alter table tenant_step_type_installs
+  alter column org_id set not null;
+
+commit;

--- a/packages/db/schema.sql
+++ b/packages/db/schema.sql
@@ -98,6 +98,9 @@ create table tenant_step_type_installs(
 
 create index tenant_step_type_installs_org_idx on tenant_step_type_installs(org_id);
 
+alter table tenant_step_type_installs
+  alter column org_id set not null;
+
 create table tenant_secret_bindings(
   id uuid primary key default gen_random_uuid(),
   org_id uuid not null references organisations(id) on delete cascade,

--- a/packages/db/tests/freshness_tables_rls.test.sql
+++ b/packages/db/tests/freshness_tables_rls.test.sql
@@ -145,12 +145,16 @@ begin
   on conflict do nothing;
 
   begin
+    v_text := null;
     insert into tenant_step_type_installs (org_id, step_type_version_id, status)
     values (null, v_step_type_version_id, 'enabled');
     raise exception 'tenant_step_type_installs.org_id should reject NULL values';
   exception
     when not_null_violation then
-      null;
+      get stacked diagnostics v_text = RETURNED_SQLSTATE;
+      if v_text <> '23502' then
+        raise exception 'Expected SQLSTATE 23502 for tenant_step_type_installs.org_id, got %', v_text;
+      end if;
   end;
   insert into platform.rule_pack_proposals (
     detection_id,


### PR DESCRIPTION
## Summary
- add a migration that backfills tenant_step_type_installs org_ids from audit_log data before enforcing NOT NULL
- update schema.sql to capture the enforced NOT NULL org_id column
- extend the freshness RLS test to assert the database raises SQLSTATE 23502 when org_id is omitted

## Testing
- pnpm --filter @airnub/db test

------
https://chatgpt.com/codex/tasks/task_e_68e0e6b855608324b144d085752ce30c