### PR TITLE
Backfill tenant overlay org scopes before enforcing NOT NULL

### DIFF
--- a/packages/db/migrations/202510050001_overlay_org_backfill.sql
+++ b/packages/db/migrations/202510050001_overlay_org_backfill.sql
@@ -1,0 +1,51 @@
+begin;
+
+perform pg_advisory_xact_lock(hashtext('tenant_workflow_overlays.org_id.not_null'));
+
+with overlay_audit_orgs as (
+  select distinct on (target_id) target_id, tenant_org_id
+  from audit_log
+  where target_kind = 'tenant_workflow_overlay'
+    and tenant_org_id is not null
+  order by target_id, created_at desc
+),
+resolved_overlays as (
+  select two.id,
+         coalesce(
+           overlay_audit_orgs.tenant_org_id,
+           snapshot_orgs.tenant_org_id,
+           wd.org_id
+         ) as resolved_org_id
+  from tenant_workflow_overlays two
+  left join overlay_audit_orgs on overlay_audit_orgs.target_id = two.id
+  left join workflow_defs wd on wd.id = two.workflow_def_id
+  left join lateral (
+    select wr.tenant_org_id
+    from workflow_overlay_snapshots s
+    join workflow_runs wr on wr.id = s.run_id
+    where s.tenant_overlay_id = two.id
+      and wr.tenant_org_id is not null
+    order by s.created_at desc
+    limit 1
+  ) snapshot_orgs on true
+  where two.org_id is null
+)
+update tenant_workflow_overlays two
+set org_id = resolved_overlays.resolved_org_id
+from resolved_overlays
+where two.id = resolved_overlays.id
+  and two.org_id is null
+  and resolved_overlays.resolved_org_id is not null;
+
+do $$
+begin
+  if exists (select 1 from tenant_workflow_overlays where org_id is null) then
+    raise exception 'tenant_workflow_overlays has NULL org_id rows after backfill';
+  end if;
+end;
+$$;
+
+alter table tenant_workflow_overlays
+  alter column org_id set not null;
+
+commit;

--- a/packages/db/tests/tenant_extension_scope.test.sql
+++ b/packages/db/tests/tenant_extension_scope.test.sql
@@ -51,6 +51,15 @@ begin
     (gen_random_uuid(), 'core-two', '1.0.0', 'Core Workflow Two', '{}'::jsonb)
   returning id into workflow_def_two;
 
+  begin
+    insert into tenant_workflow_overlays (org_id, workflow_def_id, title, patch)
+    values (null, workflow_def_one, 'Missing Org Overlay', '[]'::jsonb);
+    raise exception 'Overlay insert should fail when org_id is NULL';
+  exception
+    when sqlstate '23502' then
+      null;
+  end;
+
   insert into tenant_workflow_overlays (org_id, workflow_def_id, title, patch)
   values (tenant_two, workflow_def_two, 'Tenant Two Overlay', '[]'::jsonb)
   returning id into overlay_two;


### PR DESCRIPTION
## Summary
- backfill missing tenant_workflow_overlays org_id values before enforcing the NOT NULL constraint
- extend the tenant extension scope SQL test to assert NULL org_id inserts are rejected

## Testing
- pnpm --filter @airnub/db test

------
https://chatgpt.com/codex/tasks/task_e_68e0e6ba27108324bdc2a52e379b6cc1