### PR TITLE
feat: support overlay execution metadata

### DIFF
--- a/packages/workflow-core/schemas/workflow-definition.schema.json
+++ b/packages/workflow-core/schemas/workflow-definition.schema.json
@@ -41,7 +41,27 @@
         "taskQueue": { "type": "string" },
         "defaultTaskQueue": { "type": "string" },
         "tenantId": { "type": "string" },
-        "config": { "$ref": "#/definitions/ExecutionConfig" }
+        "config": { "$ref": "#/definitions/ExecutionConfig" },
+        "input_schema": { "type": "string" },
+        "permissions": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true
+        },
+        "secret_aliases": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true
+        },
+        "secrets": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true
+        },
+        "externalWebhook": {
+          "type": "object",
+          "additionalProperties": true
+        }
       },
       "allOf": [
         {

--- a/packages/workflow-core/src/index.ts
+++ b/packages/workflow-core/src/index.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 import Ajv, { type ErrorObject } from "ajv";
+import addMetaSchema2020Import from "ajv/dist/refs/json-schema-2020-12/index.js";
 import addFormats from "ajv-formats";
 import type {
   StepTypeDefinition,
@@ -19,6 +20,14 @@ const stepTypeSchemaPath = resolve(__dirname, "./step-type.schema.json");
 const stepTypeSchema = JSON.parse(readFileSync(stepTypeSchemaPath, "utf-8"));
 
 const ajv = new Ajv({ allErrors: true, strict: false });
+const addMetaSchema2020Module = addMetaSchema2020Import as unknown as {
+  default?: (this: Ajv, $data?: boolean) => Ajv;
+};
+const addMetaSchema2020 =
+  addMetaSchema2020Module?.default ?? (addMetaSchema2020Module as unknown as (this: Ajv, $data?: boolean) => Ajv);
+if (typeof addMetaSchema2020 === "function") {
+  addMetaSchema2020.call(ajv);
+}
 addFormats(ajv);
 const validateWorkflowSchema = ajv.compile<WorkflowDefinition>(workflowSchema);
 const validateStepTypeSchema = ajv.compile<StepTypeDefinition>(stepTypeSchema);

--- a/packages/workflow-core/src/types.ts
+++ b/packages/workflow-core/src/types.ts
@@ -4,11 +4,19 @@ export type ExecutionMode =
   | "external:webhook"
   | "external:websocket";
 
-export interface ManualStepExecution {
+export interface ExecutionOverlayMetadata {
+  input_schema?: string;
+  permissions?: string[];
+  secret_aliases?: string[];
+  secrets?: string[];
+  externalWebhook?: Record<string, unknown>;
+}
+
+export interface ManualStepExecution extends ExecutionOverlayMetadata {
   mode: "manual";
 }
 
-export interface TemporalStepExecution {
+export interface TemporalStepExecution extends ExecutionOverlayMetadata {
   mode: "temporal";
   workflow?: string;
   taskQueue?: string;
@@ -36,7 +44,7 @@ export interface WebhookExecutionConfig {
   signing?: WebhookSigningConfig;
 }
 
-export interface WebhookStepExecution {
+export interface WebhookStepExecution extends ExecutionOverlayMetadata {
   mode: "external:webhook";
   config: WebhookExecutionConfig;
 }
@@ -51,7 +59,7 @@ export interface WebsocketExecutionConfig {
   tenantId?: string;
 }
 
-export interface WebsocketStepExecution {
+export interface WebsocketStepExecution extends ExecutionOverlayMetadata {
   mode: "external:websocket";
   config: WebsocketExecutionConfig;
 }

--- a/packages/workflow-packs/package.json
+++ b/packages/workflow-packs/package.json
@@ -8,6 +8,9 @@
     "fc-pack": "bin/fc-pack.mjs"
   },
   "files": ["src", "bin"],
+  "scripts": {
+    "test": "tsx --test src/index.test.ts"
+  },
   "dependencies": {
     "@airnub/workflow-core": "workspace:*",
     "ajv": "^8.17.1",

--- a/packages/workflow-packs/src/index.test.ts
+++ b/packages/workflow-packs/src/index.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { Operation } from "fast-json-patch";
+
+import { mergeWorkflowWithPack } from "./index.js";
+import type { WorkflowPack } from "./types.js";
+import type { WorkflowDefinition } from "@airnub/workflow-core";
+
+test("mergeWorkflowWithPack accepts execution overlay metadata", () => {
+  const baseWorkflow: WorkflowDefinition = {
+    id: "setup-nonprofit-ie",
+    version: "2025.10.0",
+    title: "Setup Nonprofit IE",
+    steps: [
+      {
+        id: "revenue-chy-exemption",
+        kind: "action",
+        title: "Revenue CHY exemption"
+      },
+      {
+        id: "rbo",
+        kind: "action",
+        title: "RBO beneficial ownership",
+        requires: ["revenue-chy-exemption"]
+      },
+      {
+        id: "board-resolution",
+        kind: "action",
+        title: "Board resolution",
+        requires: ["rbo"]
+      }
+    ]
+  };
+
+  const overlayOperations: Operation[] = [
+    {
+      op: "add",
+      path: "/steps/1",
+      value: {
+        id: "tenantx-ml-screening",
+        kind: "action",
+        title: "Machine learning screening (Tenant X)",
+        execution: {
+          mode: "temporal",
+          workflow: "tenantX.mlScreening",
+          taskQueue: "tenant-x-main",
+          input_schema: "schemas/ml-screening.json",
+          permissions: ["org:member"],
+          secret_aliases: ["secrets.mlApiKey"],
+          secrets: ["secrets.legacyMlKey"],
+          externalWebhook: {
+            urlAlias: "secrets.sysY.callback"
+          }
+        }
+      }
+    },
+    {
+      op: "replace",
+      path: "/steps/2/requires",
+      value: ["tenantx-ml-screening"]
+    },
+    {
+      op: "add",
+      path: "/steps/3",
+      value: {
+        id: "tenantx-policy-attest",
+        kind: "action",
+        title: "Board policy attestation (Tenant X)",
+        execution: {
+          mode: "manual",
+          input_schema: "schemas/policy-attest.json",
+          permissions: ["org:member"]
+        },
+        requires: ["tenantx-ml-screening"]
+      }
+    },
+    {
+      op: "replace",
+      path: "/steps/4/requires",
+      value: ["tenantx-policy-attest"]
+    }
+  ];
+
+  const pack: WorkflowPack = {
+    directory: "/tmp/tenantx-pack",
+    manifest: {
+      name: "tenantx",
+      version: "1.0.0",
+      compatibleWithWorkflow: ["setup-nonprofit-ie@^2025.10"],
+      overlays: [
+        {
+          workflow: baseWorkflow.id,
+          patch: "overlay.patch.json"
+        }
+      ]
+    },
+    overlays: [
+      {
+        workflowId: baseWorkflow.id,
+        patchPath: "overlay.patch.json",
+        operations: overlayOperations
+      }
+    ],
+    schemaFiles: [
+      "schemas/ml-screening.json",
+      "schemas/policy-attest.json"
+    ]
+  };
+
+  const result = mergeWorkflowWithPack(baseWorkflow, pack);
+  const mlStep = result.workflow.steps.find((step) => step.id === "tenantx-ml-screening");
+  const policyStep = result.workflow.steps.find((step) => step.id === "tenantx-policy-attest");
+
+  assert.ok(mlStep, "ML screening step should be present after merge");
+  assert.deepEqual(mlStep?.execution?.secret_aliases, ["secrets.mlApiKey"]);
+  assert.equal(mlStep?.execution?.input_schema, "schemas/ml-screening.json");
+  assert.ok(policyStep, "Policy attestation step should be present after merge");
+  assert.equal(policyStep?.execution?.permissions?.includes("org:member"), true);
+});


### PR DESCRIPTION
## Summary
- allow workflow execution definitions to accept overlay metadata such as input schemas, permissions, and secret aliases
- expose the overlay metadata on the TypeScript execution interfaces and load the JSON Schema 2020-12 meta definitions for validation
- add a workflow pack validation test covering the tenant overlay execution metadata and wire it into the package test script

## Testing
- pnpm --filter @airnub/workflow-packs test

------
https://chatgpt.com/codex/tasks/task_e_68e0e6a0a5d48324982f384a79812726