### PR TITLE
Align tenancy schema with provider hierarchy requirements

### DIFF
--- a/apps/portal/src/lib/tenant-branding.ts
+++ b/apps/portal/src/lib/tenant-branding.ts
@@ -271,12 +271,15 @@ export async function resolveTenantBranding(
     if (typeof window !== "undefined") {
       // Browser execution falls back to the public REST endpoint.
       const { url, anonKey } = ensureSupabaseEnv();
-      const response = await fetch(`${url}/rest/v1/realms?host=eq.${encodeURIComponent(normalizedHost)}`, {
-        headers: {
-          apikey: anonKey,
-          Authorization: `Bearer ${anonKey}`
+      const response = await fetch(
+        `${url}/rest/v1/realms?domain=eq.${encodeURIComponent(normalizedHost)}`,
+        {
+          headers: {
+            apikey: anonKey,
+            Authorization: `Bearer ${anonKey}`
+          }
         }
-      });
+      );
 
       if (!response.ok) {
         throw new Error(`Failed to resolve realm (${response.status})`);
@@ -287,7 +290,7 @@ export async function resolveTenantBranding(
       const realmTheme = decodeJsonPayload(realmRow?.theme) ?? {};
       const themeRecord = realmTheme as Record<string, unknown>;
       const branding = coalesceBranding({
-        tenantOrgId: (realmRow?.org_id as string | undefined) ?? DEFAULT_TENANT_BRANDING.tenantOrgId,
+        tenantOrgId: DEFAULT_TENANT_BRANDING.tenantOrgId,
         providerOrgId: (realmRow?.provider_org_id as string | undefined) ?? null,
         realmId: (realmRow?.id as string | undefined) ?? null,
         domain: normalizedHost,
@@ -307,8 +310,8 @@ export async function resolveTenantBranding(
     const supabase = getServiceSupabaseClient();
     const { data, error } = await supabase
       .from("realms")
-      .select("id, host, org_id, provider_org_id, theme, updated_at")
-      .eq("host", normalizedHost)
+      .select("id, domain, provider_org_id, theme, updated_at")
+      .eq("domain", normalizedHost)
       .maybeSingle();
 
     if (error) {
@@ -346,7 +349,7 @@ export async function resolveTenantBranding(
     const realmTheme = decodeJsonPayload(data.theme) ?? {};
     const themeRecord = realmTheme as Record<string, unknown>;
     const branding = coalesceBranding({
-      tenantOrgId: data.org_id ?? DEFAULT_TENANT_BRANDING.tenantOrgId,
+      tenantOrgId: DEFAULT_TENANT_BRANDING.tenantOrgId,
       providerOrgId: data.provider_org_id ?? null,
       realmId: data.id ?? null,
       domain: normalizedHost,

--- a/packages/types/src/supabase.ts
+++ b/packages/types/src/supabase.ts
@@ -201,6 +201,80 @@ export type Database = {
           }
         ];
       };
+      org_memberships: {
+        Row: {
+          org_id: string;
+          user_id: string;
+          role: "member" | "org_admin" | "provider_admin" | "platform_admin";
+          status: string;
+          created_at: string;
+        };
+        Insert: {
+          org_id: string;
+          user_id: string;
+          role: "member" | "org_admin" | "provider_admin" | "platform_admin";
+          status?: string;
+          created_at?: string;
+        };
+        Update: {
+          org_id?: string;
+          user_id?: string;
+          role?: "member" | "org_admin" | "provider_admin" | "platform_admin";
+          status?: string;
+          created_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "org_memberships_org_id_fkey";
+            columns: ["org_id"];
+            isOneToOne: false;
+            referencedRelation: "orgs";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "org_memberships_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+      orgs: {
+        Row: {
+          id: string;
+          name: string;
+          type: "platform" | "provider" | "customer";
+          parent_org_id: string | null;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          name: string;
+          type: "platform" | "provider" | "customer";
+          parent_org_id?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          name?: string;
+          type?: "platform" | "provider" | "customer";
+          parent_org_id?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "orgs_parent_org_id_fkey";
+            columns: ["parent_org_id"];
+            isOneToOne: false;
+            referencedRelation: "orgs";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       release_notes: {
         Row: {
           id: string;
@@ -1233,6 +1307,41 @@ export type Database = {
             columns: ["step_type_version_id"];
             isOneToOne: false;
             referencedRelation: "platform.step_type_versions";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+      realms: {
+        Row: {
+          id: string;
+          domain: string;
+          provider_org_id: string;
+          theme: Json | null;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          domain: string;
+          provider_org_id: string;
+          theme?: Json | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          domain?: string;
+          provider_org_id?: string;
+          theme?: Json | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "realms_provider_org_id_fkey";
+            columns: ["provider_org_id"];
+            isOneToOne: false;
+            referencedRelation: "orgs";
             referencedColumns: ["id"];
           }
         ];

--- a/supabase/migrations/202510060001_create_tenancy_core.sql
+++ b/supabase/migrations/202510060001_create_tenancy_core.sql
@@ -3,17 +3,20 @@ set check_function_bodies = off;
 
 create table if not exists public.orgs (
   id uuid primary key default gen_random_uuid(),
-  slug text unique not null,
   name text not null,
-  metadata jsonb not null default '{}'::jsonb,
+  type text not null check (type in ('platform', 'provider', 'customer')),
+  parent_org_id uuid references public.orgs(id) on delete set null,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
 );
 
+create index if not exists orgs_parent_idx on public.orgs (parent_org_id);
+
 create table if not exists public.org_memberships (
   org_id uuid not null references public.orgs(id) on delete cascade,
   user_id uuid not null,
-  role text not null check (role in ('owner', 'admin', 'member', 'provider_admin')),
+  role text not null check (role in ('member', 'org_admin', 'provider_admin', 'platform_admin')),
+  status text not null default 'active',
   created_at timestamptz not null default now(),
   primary key (org_id, user_id)
 );
@@ -21,15 +24,16 @@ create table if not exists public.org_memberships (
 create index if not exists org_memberships_user_role_idx
   on public.org_memberships (user_id, role);
 
+create index if not exists org_memberships_org_status_idx
+  on public.org_memberships (org_id, status);
+
 create table if not exists public.realms (
   id uuid primary key default gen_random_uuid(),
-  host text not null unique,
-  org_id uuid not null references public.orgs(id) on delete cascade,
-  provider_org_id uuid references public.orgs(id) on delete set null,
-  theme jsonb not null default '{}'::jsonb,
+  domain text not null unique,
+  provider_org_id uuid not null references public.orgs(id) on delete cascade,
+  theme jsonb,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
 );
 
-create index if not exists realms_org_idx on public.realms (org_id);
 create index if not exists realms_provider_idx on public.realms (provider_org_id);


### PR DESCRIPTION
## Summary
- update the tenancy core migration to add organisation types, parent linkage, membership status, and provider-scoped realms
- refresh Supabase Database typings for the new orgs, org_memberships, and realms tables
- adjust the portal tenant branding resolver to look up realms by domain without tenant org references

## Testing
- `pnpm --filter @airnub/portal lint` *(fails: Next.js CLI not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0f9f7aa608324b7388832dff60245