### PR TITLE
Add org hierarchy metadata and recursive provider admin helper

### DIFF
--- a/scripts/rls-smoke.test.mjs
+++ b/scripts/rls-smoke.test.mjs
@@ -30,8 +30,8 @@ assertRegex(
 );
 
 assertRegex(
-  /create\s+or\s+replace\s+function\s+app\.is_provider_admin_for[\s\S]+public\.realms/i,
-  "Provider admin helper must reference public.realms for ancestry resolution."
+  /create\s+or\s+replace\s+function\s+app\.is_provider_admin_for[\s\S]+with\s+recursive[\s\S]+public\.orgs[\s\S]+m\.role\s+in\s+\('provider_admin',\s*'org_admin'\)/i,
+  "Provider admin helper must traverse the org hierarchy with a recursive CTE and honor provider/org admin memberships."
 );
 
 // Platform catalog policies must be locked to app.is_platform_admin

--- a/supabase/migrations/202510060007_update_org_hierarchy.sql
+++ b/supabase/migrations/202510060007_update_org_hierarchy.sql
@@ -1,0 +1,147 @@
+-- Enrich org hierarchy metadata and update provider admin helper
+set check_function_bodies = off;
+
+-- Ensure orgs table carries hierarchy metadata
+alter table public.orgs
+  add column if not exists type text;
+
+alter table public.orgs
+  add column if not exists parent_org_id uuid;
+
+alter table public.orgs
+  drop constraint if exists orgs_type_check;
+
+alter table public.orgs
+  add constraint orgs_type_check
+  check (type in ('platform', 'provider', 'customer'));
+
+alter table public.orgs
+  drop constraint if exists orgs_parent_org_id_fkey;
+
+alter table public.orgs
+  add constraint orgs_parent_org_id_fkey
+  foreign key (parent_org_id)
+  references public.orgs(id)
+  on delete restrict;
+
+create index if not exists orgs_type_idx on public.orgs (type);
+create index if not exists orgs_parent_idx on public.orgs (parent_org_id);
+
+-- Backfill hierarchy data based on existing memberships and realm ownership
+DO $$
+DECLARE
+  realm_customer_column text;
+BEGIN
+  -- Identify platform orgs from existing platform admin memberships
+  update public.orgs o
+     set type = 'platform',
+         parent_org_id = null
+   where exists (
+           select 1
+             from public.org_memberships m
+            where m.org_id = o.id
+              and m.role = 'platform_admin'
+         );
+
+  -- Flag providers using realm ownership or elevated memberships
+  update public.orgs o
+     set type = 'provider',
+         parent_org_id = null
+   where o.type is distinct from 'platform'
+     and (
+       exists (
+         select 1
+           from public.realms r
+          where r.provider_org_id = o.id
+       )
+       or exists (
+         select 1
+           from public.org_memberships m
+          where m.org_id = o.id
+            and m.role in ('provider_admin', 'org_admin')
+       )
+     );
+
+  -- Detect which column (if any) links realms to customer orgs
+  select column_name
+    into realm_customer_column
+    from information_schema.columns
+   where table_schema = 'public'
+     and table_name = 'realms'
+     and column_name in ('org_id', 'tenant_org_id', 'customer_org_id')
+   order by case column_name
+              when 'org_id' then 1
+              when 'tenant_org_id' then 2
+              else 3
+            end
+   limit 1;
+
+  if realm_customer_column is not null then
+    execute format(
+      $sql$
+        update public.orgs c
+           set parent_org_id = r.provider_org_id,
+               type = case
+                 when c.type in ('platform', 'provider') then c.type
+                 else 'customer'
+               end
+          from public.realms r
+         where r.%I = c.id
+           and r.provider_org_id <> c.id
+      $sql$,
+      realm_customer_column
+    );
+  end if;
+
+  -- Default any remaining orgs to customers when type is still null
+  update public.orgs
+     set type = 'customer'
+   where type is null;
+END$$;
+
+create or replace function app.is_provider_admin_for(target_org_id uuid)
+  returns boolean
+  language plpgsql
+  stable
+as $$
+declare
+  subject uuid;
+begin
+  if target_org_id is null then
+    return false;
+  end if;
+
+  begin
+    subject := (app.jwt()->>'sub')::uuid;
+  exception when others then
+    return false;
+  end;
+
+  if subject is null then
+    return false;
+  end if;
+
+  return exists (
+    with recursive ancestors as (
+      select o.id, o.parent_org_id, o.type
+        from public.orgs o
+       where o.id = target_org_id
+      union all
+      select parent.id, parent.parent_org_id, parent.type
+        from public.orgs parent
+        join ancestors child
+          on child.parent_org_id = parent.id
+    )
+    select 1
+      from ancestors a
+      join public.orgs provider
+        on provider.id = a.id
+       and provider.type = 'provider'
+      join public.org_memberships m
+        on m.org_id = provider.id
+       and m.user_id = subject
+       and m.status = 'active'
+       and m.role in ('provider_admin', 'org_admin')
+  );
+end;
+$$;

--- a/supabase/tests/provider_admin_hierarchy.sql
+++ b/supabase/tests/provider_admin_hierarchy.sql
@@ -1,0 +1,34 @@
+-- Verify provider admin hierarchy traversal does not require a realm row
+DO $$
+DECLARE
+  provider_id uuid := gen_random_uuid();
+  customer_id uuid := gen_random_uuid();
+  provider_admin_id uuid := gen_random_uuid();
+  has_access boolean;
+BEGIN
+  insert into public.orgs (id, name, type, parent_org_id)
+  values
+    (provider_id, 'Test Provider Org (hierarchy regression)', 'provider', null),
+    (customer_id, 'Test Customer Org (hierarchy regression)', 'customer', provider_id);
+
+  insert into public.org_memberships (org_id, user_id, role, status)
+  values
+    (provider_id, provider_admin_id, 'provider_admin', 'active');
+
+  perform set_config('request.jwt.claims', jsonb_build_object('sub', provider_admin_id)::text, true);
+
+  select app.is_provider_admin_for(customer_id) into has_access;
+  if not has_access then
+    raise exception 'Expected provider admin to reach customer via hierarchy metadata';
+  end if;
+
+  select app.has_org_access(customer_id) into has_access;
+  if not has_access then
+    raise exception 'app.has_org_access should grant provider admin access to descendant customers';
+  end if;
+
+  perform set_config('request.jwt.claims', '{}'::text, true);
+
+  delete from public.org_memberships where org_id = provider_id and user_id = provider_admin_id;
+  delete from public.orgs where id in (customer_id, provider_id);
+END$$;


### PR DESCRIPTION
## Summary
- add a migration to enrich public.orgs with hierarchy metadata, backfill existing data, and rewrite app.is_provider_admin_for to use a recursive CTE
- update the RLS smoke test to assert the recursive helper pattern
- add a regression SQL test ensuring provider admins can reach descendant customers without relying on realms

## Testing
- node scripts/rls-smoke.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68e10ffccd188324a89ec041354f8193