### PR TITLE
Fix provider admin helper to use org hierarchy

### DIFF
--- a/supabase/migrations/202510060007_update_org_hierarchy.sql
+++ b/supabase/migrations/202510060007_update_org_hierarchy.sql
@@ -141,7 +141,7 @@ begin
         on m.org_id = provider.id
        and m.user_id = subject
        and m.status = 'active'
-       and m.role in ('provider_admin', 'org_admin')
+       and m.role = 'provider_admin'
   );
 end;
 $$;

--- a/supabase/tests/provider_admin_hierarchy.sql
+++ b/supabase/tests/provider_admin_hierarchy.sql
@@ -4,6 +4,7 @@ DECLARE
   provider_id uuid := gen_random_uuid();
   customer_id uuid := gen_random_uuid();
   provider_admin_id uuid := gen_random_uuid();
+  unrelated_user_id uuid := gen_random_uuid();
   has_access boolean;
 BEGIN
   insert into public.orgs (id, name, type, parent_org_id)
@@ -25,6 +26,18 @@ BEGIN
   select app.has_org_access(customer_id) into has_access;
   if not has_access then
     raise exception 'app.has_org_access should grant provider admin access to descendant customers';
+  end if;
+
+  perform set_config('request.jwt.claims', jsonb_build_object('sub', unrelated_user_id)::text, true);
+
+  select app.is_provider_admin_for(customer_id) into has_access;
+  if has_access then
+    raise exception 'Unrelated user should not be treated as provider admin for customer org';
+  end if;
+
+  select app.has_org_access(customer_id) into has_access;
+  if has_access then
+    raise exception 'Unrelated user should not have org access to customer org';
   end if;
 
   perform set_config('request.jwt.claims', '{}'::text, true);


### PR DESCRIPTION
## Summary
- update the initial app.is_provider_admin_for helper to traverse org hierarchy metadata and require provider_admin membership
- align the hierarchy follow-up migration to the same provider_admin role enforcement
- extend the provider admin hierarchy regression test to confirm unrelated users are rejected

## Testing
- not run (Supabase CLI unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e115c53a0c8324b4d1ba65a6a117fc