### PR TITLE
Strengthen provider hierarchy traversal for org access

### DIFF
--- a/scripts/rls-smoke.test.mjs
+++ b/scripts/rls-smoke.test.mjs
@@ -61,6 +61,17 @@ assertRegex(
   "Provider admin helper must traverse the org hierarchy with a recursive CTE and honor provider/org admin memberships.",
 );
 
+const migrationIsProviderAdminFor = extractFunctionDefinition(
+  migrationSql,
+  "app.is_provider_admin_for",
+);
+
+if (/public\.realms/i.test(migrationIsProviderAdminFor)) {
+  throw new Error(
+    "Provider admin helper must rely on org hierarchy metadata instead of public.realms joins.",
+  );
+}
+
 // Platform catalog policies must be locked to app.is_platform_admin
 assertRegex(
   /create\s+policy[\s\S]+on\s+platform\.rule_catalogs[\s\S]+app\.is_platform_admin\(\)/i,


### PR DESCRIPTION
## Summary
- add a Supabase migration that enforces org hierarchy metadata, backfills type/parent values, and redefines the provider admin helper with ancestor traversal
- update existing helper definitions and the RLS smoke test to require the recursive pattern instead of realms joins
- extend the hierarchy regression test so provider org admins and provider admins both gain descendant access

## Testing
- pnpm test:rls-smoke

------
https://chatgpt.com/codex/tasks/task_e_68e124f674508324ac8dd8fd75e64c7f