### PR TITLE
Replace tenant_org_id references

### DIFF
--- a/.github/workflows/db-baseline-guard.yml
+++ b/.github/workflows/db-baseline-guard.yml
@@ -10,11 +10,11 @@ jobs:
           # Warn on ALTER churn/backfill patterns in new migrations
           NEW_SQL=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep -E '\.sql$' || true)
           if [ -n "$NEW_SQL" ]; then
-            echo "$NEW_SQL" | xargs -I{} grep -nE "(BACKFILL|UPDATE .* SET .* =|INSERT INTO .* SELECT|\\balter\\b .* (drop|rename)|\\btenant_org_id\\b)" {} || true
+            echo "$NEW_SQL" | xargs -I{} grep -nE "(BACKFILL|UPDATE .* SET .* =|INSERT INTO .* SELECT|\\balter\\b .* (drop|rename)|\\bparent_org_id\\b)" {} || true
           fi
       - name: Forbid tenancy gates via IS NULL (ownership)
         run: |
-          if rg -n --hidden -S "(org_id|tenant_org_id)\\s+is\\s+null" --glob "**/*.sql"; then
+          if rg -n --hidden -S "(org_id|parent_org_id)\\s+is\\s+null" --glob "**/*.sql"; then
             echo "Forbidden tenancy gate via IS NULL detected in SQL." >&2
             exit 1
           fi

--- a/.github/workflows/policy-rls.yml
+++ b/.github/workflows/policy-rls.yml
@@ -11,7 +11,7 @@ jobs:
           set -euo pipefail
           mapfile -d '' matches < <(
             grep -RPzl --include='*.sql' \
-              'create\s+policy[\s\S]{0,200}(org_id|tenant_org_id)\s+is\s+null' \
+              'create\s+policy[\s\S]{0,200}(org_id|parent_org_id)\s+is\s+null' \
               packages/db/migrations supabase/migrations || true
           )
 

--- a/docs/_archive/2025-10-04/FreshComply-Spec.md
+++ b/docs/_archive/2025-10-04/FreshComply-Spec.md
@@ -72,7 +72,7 @@ FreshComply enables multi-tenant compliance with:
   - Enable RLS; allow **admin** read/write; tenant access via **views/RPCs** only.
 
 ## 7) Change Control & CI
-- CI blocks: any RLS that checks `org_id IS NULL` or `tenant_org_id IS NULL`
+- CI blocks: any RLS that checks `org_id IS NULL` or `parent_org_id IS NULL`
 - CI blocks: any client/browser path attempting to **write** to `platform.*`
 - PR template: explicit checkbox “This PR edits locked governance docs” (must be labeled)
 - Branch protections: main is protected; 2 approvals required for locked files

--- a/docs/architecture/0003-white-label-multi-tenant-architecture.v1.0.0.md
+++ b/docs/architecture/0003-white-label-multi-tenant-architecture.v1.0.0.md
@@ -26,7 +26,7 @@ Partners such as accounting firms want to offer FreshComply under their own bran
 
 ## Consequences
 
-- Introduce explicit tenant hierarchy (`platform → partner → client`) with Supabase RLS enforcing row ownership via `tenant_org_id` and `subject_org_id`.
+- Introduce explicit tenant hierarchy (`platform → partner → client`) with Supabase RLS enforcing row ownership via `org_id` and `subject_org_id`.
 - Add per-tenant configuration for branding, documents, and outbound communications, including custom domains, DKIM/SPF verification, and PDF/email theming.
 - Route Temporal workflows through tenant-specific task queues (`tenant-{id}-main`) and tag spans/logs with tenant metadata for observability.
 - Manage external integrations via tenant-scoped secret aliases and hardened webhook ingress that verifies HMAC signatures, timestamps, and replay protection.

--- a/docs/specs/fresh-comply-workflow-agnostic-extension-model-tenant-overlays-spec.v1.0.0.md
+++ b/docs/specs/fresh-comply-workflow-agnostic-extension-model-tenant-overlays-spec.v1.0.0.md
@@ -189,7 +189,7 @@ features: ["temporal", "docs"]
 ```
 workflow_packs(id, name, publisher, marketplace boolean, created_at)
 workflow_pack_versions(id, pack_id, version, manifest_json, overlay_json, checksum, created_at)
-workflow_pack_installs(id, pack_version_id, tenant_org_id, enabled boolean, created_at, disabled_at)
+workflow_pack_installs(id, pack_version_id, org_id, enabled boolean, created_at, disabled_at)
 workflow_overlays_resolved(id, run_id, pack_version_id, resolved_overlay_json, created_at)
 ```
 
@@ -216,7 +216,7 @@ fc pack install    # POST to admin API for a tenant
 ## 12) Observability & Audit
 
 - Correlate steps to overlays via `workflow_overlays_resolved`.  
-- Structured logs include `pack_version_id`, `tenant_org_id`, `run_id`, `step_id`.  
+- Structured logs include `pack_version_id`, `org_id`, `run_id`, `step_id`.
 - Expose metrics: overlay validation failures, merge conflicts, policy lint failures.
 
 ---

--- a/docs/specs/freshcomply-consolidated-spec.v1.0.0.md
+++ b/docs/specs/freshcomply-consolidated-spec.v1.0.0.md
@@ -17,7 +17,7 @@ status: Stable
 
 ## 1. Tenancy Model (public schema)
 
-- Every tenant-scoped table stores a hard, non-null `org_id` or `tenant_org_id` column that points at `public.organisations(id)`.
+- Every tenant-scoped table stores a hard, non-null `org_id` or `parent_org_id` column that points at `public.organisations(id)`.
 - Supabase Row Level Security (RLS) is enabled on all tenant tables. Policies rely on membership helpers instead of nullable org columns.
 - `app.is_org_member(target_org uuid)` gatekeeps tenant operations. It returns `true` when:
   - the request comes from the Supabase service role,
@@ -28,8 +28,8 @@ status: Stable
 
 ### Tenancy guarantees
 
-- Inserts/updates must provide a tenant id; migrations enforce `NOT NULL` on `org_id`/`tenant_org_id` and add covering indexes for lookup performance.
-- RPCs that accept `tenant_org_id` call `public.assert_tenant_membership` to reject null context and unauthorized access.
+- Inserts/updates must provide a tenant id; migrations enforce `NOT NULL` on `org_id`/`parent_org_id` and add covering indexes for lookup performance.
+- RPCs that accept `org_id` call `public.assert_tenant_membership` to reject null context and unauthorized access.
 - Temporal workflows, document generation, and DSR processing all reference the tenant id so that downstream audit entries and webhooks carry the correct scope.
 
 ## 2. Platform Schema (global assets)
@@ -58,14 +58,14 @@ create or replace function app.is_org_member(target_org uuid) returns boolean;
 
 1. Create helper functions first (`app` schema) so subsequent migrations can rely on them idempotently.
 2. Introduce new `platform.*` tables, copy shared rows from public tables, and delete legacy NULL-tenant rows.
-3. Rename `tenant_org_id` to `org_id` when scoping to the owning tenant for clarity; immediately enforce `NOT NULL` + indexes.
+3. Standardise tenant columns on `org_id` when scoping to the owning tenant; immediately enforce `NOT NULL` + indexes.
 4. Rebuild RLS policies to use `app.is_org_member()` and `app.is_platform_admin()`—never fall back to `... IS NULL` guards.
 5. Add read-only views/RPCs when tenants need catalog access (e.g., `public.v_step_types`).
 6. Write regression migrations that assert no NULL tenant keys remain before tightening constraints (see 202510040001_tenant_overlay_install_scope.sql).
 
 ## 5. CI Guardrails
 
-- `.github/workflows/policy-rls.yml` fails if any SQL file reintroduces `org_id IS NULL` / `tenant_org_id IS NULL` checks in policies.
+- `.github/workflows/policy-rls.yml` fails if any SQL file reintroduces `org_id IS NULL` / `parent_org_id IS NULL` checks in policies.
 - The same workflow blocks client bundles from calling `supabase.from('platform.*').insert/update/upsert/delete`.
 - `packages/db/check-rls.mjs` validates `schema.sql` includes RLS enablement and lacks forbidden NULL tenancy gates.
 

--- a/docs/specs/white-label-architecture.v1.0.0.md
+++ b/docs/specs/white-label-architecture.v1.0.0.md
@@ -30,9 +30,9 @@ status: Stable
 - **Client Organisation (Company X)** → Operates its workflows, users, artefacts, and filings; full visibility on steps and deadlines.
 
 **Isolation (Supabase RLS)**
-- Every row stores `tenant_org_id` and (when relevant) `subject_org_id`.
+- Every row stores `org_id` and (when relevant) `subject_org_id`.
 - Policies only allow:
-  - Tenant users to read/write their tenant data and the client runs they **engage** (`engager_org_id = tenant_org_id`).
+  - Tenant users to read/write their tenant data and the client runs they **engage** (`engager_org_id = org_id`).
   - Client users to read/write their own `subject_org_id` data.
   - Platform admins via server-minted `{ role: 'platform_admin' }` (or boolean override) tokens; service-role keys stay server-only via `public.is_platform_service()` and are audited.
 
@@ -45,7 +45,7 @@ status: Stable
 
 **Custom Domains**
 - Table: `tenant_domains(tenant_id, domain, verified_at, cert_status)`.
-- Next.js **Middleware** resolves `Host` → `tenant_org_id`, loads branding, and injects it server‑side. All tenants share the same app binary.
+- Next.js **Middleware** resolves `Host` → `org_id`, loads branding, and injects it server‑side. All tenants share the same app binary.
 - Automated certificate issuance (ACME) with DNS validation; status visible in Partner Admin.
 
 **Brand Theming**
@@ -111,9 +111,9 @@ Stripe Connect + Billing recommended; invoices, tax/VAT handling, and payouts ar
 
 ## 7) Audit Trail & DSR
 
-- **Append-only ledgers**: `audit_log` (tenant event stream) and `admin_actions` (platform-admin mutations) capture `{ id, tenant_org_id, subject_org_id, actor_user_id, actor_org_id, on_behalf_of_org_id, action, payload jsonb, created_at, prev_hash, curr_hash }` with immutable retention windows that satisfy [SOC 2 audit evidence requirements](./fresh-comply-spec.md#soc-2-compliance-requirements).
-- **Hash-chain enforcement**: Postgres `BEFORE INSERT` trigger sets `curr_hash = sha256(prev_hash || row_digest)` and verifies `prev_hash` equals the latest committed hash per `(tenant_org_id, stream_key)`; `UPDATE`/`DELETE` are blocked via RLS and constraint triggers so the chain cannot be rewritten.
-- **RLS views**: expose tenant-safe `audit_log_view` / `admin_actions_view` filtering by `tenant_org_id` and enriching actor metadata; platform-only variants can traverse cross-tenant `subject_org_id` for DSR and incident response. The [Admin App Spec](./admin-app-spec.md) consumes the platform view for moderation tooling.
+- **Append-only ledgers**: `audit_log` (tenant event stream) and `admin_actions` (platform-admin mutations) capture `{ id, org_id, subject_org_id, actor_user_id, actor_org_id, on_behalf_of_org_id, action, payload jsonb, created_at, prev_hash, curr_hash }` with immutable retention windows that satisfy [SOC 2 audit evidence requirements](./fresh-comply-spec.md#soc-2-compliance-requirements).
+- **Hash-chain enforcement**: Postgres `BEFORE INSERT` trigger sets `curr_hash = sha256(prev_hash || row_digest)` and verifies `prev_hash` equals the latest committed hash per `(org_id, stream_key)`; `UPDATE`/`DELETE` are blocked via RLS and constraint triggers so the chain cannot be rewritten.
+- **RLS views**: expose tenant-safe `audit_log_view` / `admin_actions_view` filtering by `org_id` and enriching actor metadata; platform-only variants can traverse cross-tenant `subject_org_id` for DSR and incident response. The [Admin App Spec](./admin-app-spec.md) consumes the platform view for moderation tooling.
 - **RPC write-through pattern**: all admin surfaces and automated workflows call `rpc_append_audit_entry(actor, action, payload)` which writes to `admin_actions`, returns the hash link, and emits NOTIFY for workers that append to `audit_log` so UI latency stays low.
 - **DSR lifecycle coverage**: DSR intake, acknowledgement, hold, fulfillment, and closure events append to `audit_log` with legal basis, SLA timestamps, and export bundle references; exports include the latest hash signature to prove integrity during regulator handoffs.
 
@@ -128,10 +128,10 @@ tenant_branding(tenant_id, tokens jsonb, logo_url, favicon_url, pdf_footer, typo
 tenant_secret_bindings(id, tenant_id, alias, provider, provider_ref, created_at)
 
 -- Existing tables extend with tenant context where not present
-organisations(subject_org_id, tenant_org_id, ...)
-engagements(actor_org_id, on_behalf_of_org_id, tenant_org_id, ...)
+organisations(subject_org_id, parent_org_id, ...)
+engagements(actor_org_id, on_behalf_of_org_id, org_id, ...)
 steps(..., execution_mode, orchestration_workflow_id, external_ref, artifacts jsonb)
-workflow_runs(..., tenant_org_id, merged_workflow_snapshot jsonb)
+workflow_runs(..., org_id, merged_workflow_snapshot jsonb)
 
 -- Step Type Registry (global) + tenant installs
 a) step_types(id, slug, latest_version, ...)

--- a/scripts/rls-smoke.test.mjs
+++ b/scripts/rls-smoke.test.mjs
@@ -190,7 +190,7 @@ assertRegex(
 );
 
 // Negative coverage: forbid tenancy gates that rely on IS NULL checks within migrations
-if (/create\s+policy[\s\S]{0,200}(tenant_org_id|org_id)\s+is\s+null/i.test(migrationSql)) {
+if (/create\s+policy[\s\S]{0,200}(parent_org_id|org_id)\s+is\s+null/i.test(migrationSql)) {
   throw new Error("Migrations must not rely on tenancy columns with IS NULL guards inside policies.");
 }
 

--- a/supabase/migrations/202510060004_migrate_global_rows.sql
+++ b/supabase/migrations/202510060004_migrate_global_rows.sql
@@ -9,22 +9,22 @@ begin
   for rec in
     select table_schema, table_name
     from information_schema.columns
-    where column_name = 'tenant_org_id'
+    where column_name = 'org_id'
       and table_schema = 'public'
   loop
-    execute format('select exists (select 1 from %I.%I where tenant_org_id is null)', rec.table_schema, rec.table_name)
+    execute format('select exists (select 1 from %I.%I where org_id is null)', rec.table_schema, rec.table_name)
       into has_null;
 
     if has_null then
       execute format(
         'insert into platform.global_records (source_table, payload)
-         select %L, to_jsonb(t) from %I.%I t where tenant_org_id is null',
+         select %L, to_jsonb(t) from %I.%I t where org_id is null',
         rec.table_schema || '.' || rec.table_name,
         rec.table_schema,
         rec.table_name
       );
 
-      execute format('delete from %I.%I where tenant_org_id is null', rec.table_schema, rec.table_name);
+      execute format('delete from %I.%I where org_id is null', rec.table_schema, rec.table_name);
     end if;
   end loop;
 end$$;

--- a/supabase/migrations/202510060005_normalize_org_columns.sql
+++ b/supabase/migrations/202510060005_normalize_org_columns.sql
@@ -1,4 +1,4 @@
--- Rename tenant_org_id columns to org_id and enforce strict constraints
+-- Enforce strict constraints on org_id columns
 set check_function_bodies = off;
 
 do $$
@@ -11,21 +11,20 @@ begin
   for rec in
     select table_schema, table_name
     from information_schema.columns
-    where column_name = 'tenant_org_id'
+    where column_name = 'org_id'
       and table_schema = 'public'
   loop
     qualified := format('%I.%I', rec.table_schema, rec.table_name);
 
-    execute format('select exists (select 1 from %s where tenant_org_id is null)', qualified)
+    execute format('select exists (select 1 from %s where org_id is null)', qualified)
       into has_null;
 
     if has_null then
-      raise exception 'Table % has NULL tenant_org_id rows; global rows must be migrated before enforcing tenancy.', qualified;
+      raise exception 'Table % has NULL org_id rows; global rows must be migrated before enforcing tenancy.', qualified;
     end if;
 
-    execute format('alter table %s alter column tenant_org_id type uuid using tenant_org_id::uuid', qualified);
-    execute format('alter table %s alter column tenant_org_id set not null', qualified);
-    execute format('alter table %s rename column tenant_org_id to org_id', qualified);
+    execute format('alter table %s alter column org_id type uuid using org_id::uuid', qualified);
+    execute format('alter table %s alter column org_id set not null', qualified);
 
     idx_name := format('%s_org_id_idx', rec.table_name);
     execute format('create index if not exists %I on %s (org_id)', idx_name, qualified);

--- a/supabase/migrations/202510060007_update_org_hierarchy.sql
+++ b/supabase/migrations/202510060007_update_org_hierarchy.sql
@@ -68,10 +68,10 @@ BEGIN
     from information_schema.columns
    where table_schema = 'public'
      and table_name = 'realms'
-     and column_name in ('org_id', 'tenant_org_id', 'customer_org_id')
-   order by case column_name
-              when 'org_id' then 1
-              when 'tenant_org_id' then 2
+    and column_name in ('org_id', 'parent_org_id', 'customer_org_id')
+  order by case column_name
+             when 'org_id' then 1
+              when 'parent_org_id' then 2
               else 3
             end
    limit 1;

--- a/supabase/migrations/202510060008_strengthen_org_hierarchy.sql
+++ b/supabase/migrations/202510060008_strengthen_org_hierarchy.sql
@@ -67,10 +67,10 @@ BEGIN
     from information_schema.columns
    where table_schema = 'public'
      and table_name = 'realms'
-     and column_name in ('org_id', 'tenant_org_id', 'customer_org_id')
-   order by case column_name
-              when 'org_id' then 1
-              when 'tenant_org_id' then 2
+    and column_name in ('org_id', 'parent_org_id', 'customer_org_id')
+  order by case column_name
+             when 'org_id' then 1
+              when 'parent_org_id' then 2
               else 3
             end
    limit 1;


### PR DESCRIPTION
## Summary
- replace tenancy references to use org_id or parent_org_id across migrations, guards, and docs
- update RLS smoke test and CI regexes to align with new column names

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e12a64a2848324ac07c72d4714a86c